### PR TITLE
User 테이블 생성 및 get 요청 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,14 +8,29 @@ group = 'net.chatfoodie'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 }
 
 tasks.named('test') {

--- a/server/src/main/java/net/chatfoodie/server/ServerApplication.java
+++ b/server/src/main/java/net/chatfoodie/server/ServerApplication.java
@@ -39,7 +39,7 @@ public class ServerApplication {
         try {
             output = new FileOutputStream(propertiesFile);
 
-            prop.setProperty("spring.datasource.url", "jdbc:mysql://localhost:3306/chatfoodie?jdbc:mysql://localhost:3306/chatfoodie?rewriteBatchedStatements=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul");
+            prop.setProperty("spring.datasource.url", "jdbc:mysql://localhost:3306/chatfoodie?rewriteBatchedStatements=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul");
             prop.setProperty("spring.datasource.username", "${your username}");
             prop.setProperty("spring.datasource.password", "${your password}");
 

--- a/server/src/main/java/net/chatfoodie/server/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/controller/UserController.java
@@ -1,0 +1,23 @@
+package net.chatfoodie.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import net.chatfoodie.server.domain.user.dto.UserDto;
+import net.chatfoodie.server.domain.user.service.UserReadService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    final private UserReadService userReadService;
+
+    @GetMapping("/{id}")
+    public UserDto getUser(@PathVariable Long id) {
+
+        return userReadService.getUserById(id);
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/ddl.sql
+++ b/server/src/main/java/net/chatfoodie/server/ddl.sql
@@ -1,1 +1,22 @@
 # table schema
+
+CREATE TABLE IF NOT EXISTS user (
+    id INT AUTO_INCREMENT,
+    login_id VARCHAR(40) NOT NULL,
+    password VARCHAR(64) NOT NULL,
+    name VARCHAR(20) DEFAULT '회원',
+    gender TINYINT(1) DEFAULT 0,
+    birth DATE DEFAULT (CURRENT_DATE),
+    email VARCHAR(100),
+    created_at TIMESTAMP DEFAULT now(),
+    CONSTRAINT user_id_uindex PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS admin (
+    id INT AUTO_INCREMENT,
+    login_id VARCHAR(40) NOT NULL,
+    password VARCHAR(64) NOT NULL,
+    name VARCHAR(20) DEFAULT '관리자',
+    created_at TIMESTAMP DEFAULT now(),
+    CONSTRAINT admin_id_uindex PRIMARY KEY (id)
+);

--- a/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserDto.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserDto.java
@@ -1,0 +1,13 @@
+package net.chatfoodie.server.domain.user.dto;
+
+import java.time.LocalDate;
+
+public record UserDto(
+        Long id,
+        String loginId,
+        String name,
+        Boolean gender,
+        LocalDate birth,
+        String email
+) {
+}

--- a/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
@@ -1,0 +1,47 @@
+package net.chatfoodie.server.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String login_id;
+
+    private String password;
+
+    private String name;
+
+    private Boolean gender;
+
+    private LocalDate birth;
+
+    private String email;
+
+    private LocalDateTime created_at;
+
+    @Builder
+    public User(Long id, String login_id, String password, String name, Boolean gender, LocalDate birth, String email, LocalDateTime created_at) {
+        this.id = id;
+        this.login_id = Objects.requireNonNull(login_id);
+        this.password = Objects.requireNonNull(password);
+        this.name = name == null ? "회원" : name;
+        this.gender = gender == null ? false : gender;
+        this.birth = birth == null ? LocalDate.now() : birth;
+        this.email = email == null ? "" : email;
+        this.created_at = created_at == null ? LocalDateTime.now() : created_at;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/domain/user/repository/UserRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package net.chatfoodie.server.domain.user.repository;
+
+
+import net.chatfoodie.server.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/server/src/main/java/net/chatfoodie/server/domain/user/service/UserReadService.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/service/UserReadService.java
@@ -1,0 +1,31 @@
+package net.chatfoodie.server.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import net.chatfoodie.server.domain.user.dto.UserDto;
+import net.chatfoodie.server.domain.user.entity.User;
+import net.chatfoodie.server.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserReadService {
+    final private UserRepository userRepository;
+
+    public UserDto getUserById(Long id) {
+        var user = userRepository.findById(id).orElseThrow();
+        return toDto(user);
+    }
+
+    private UserDto toDto(User user) {
+        return new UserDto(
+                user.getId(),
+                user.getLogin_id(),
+                user.getName(),
+                user.getGender(),
+                user.getBirth(),
+                user.getEmail()
+        );
+    }
+
+
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,13 +1,15 @@
+spring.profiles.include=settings
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.database=mysql
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 logging.level.org.hibernate=info
+
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
-spring.profiles.include=settings
+spring.jpa.open-in-view=false


### PR DESCRIPTION
## Summary

user 테이블과 admin 테이블을 생성, user의 경우 domain을 만들어 JPA로 값을 읽는 것 까지 확인

## Description

- 먼저 라이브러리(JPA, swagger ui, mysql, lombok)를 gradle로 import하여 잘 되는 걸 확인함.
- ddl에 테이블 스키마를 작성하고 Entity를 생성(정확한 JPA 사용법을 현재 모르는 중이라 불필요한 코드가 존재 할 수도 있음)
- Service 로직으로 getUserById(id: Long) :UserDto 를 생성함
- Controller에서 getmapping

> 현재 swagger를 연결해놨기 때문에 테스트를 하고 싶으면 서버를 실행 후 http://localhost:8080/swagger-ui/index.html로 접속하면 UI를 사용하여 api 테스트 가능