### PR TITLE
spring security 및 jwt 발급 테스트(회원가입 / 로그인)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,10 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
@@ -30,6 +34,13 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // local
+    runtimeOnly 'com.h2database:h2'
+
+    // third party
+    implementation group: 'com.auth0', name: 'java-jwt', version: '4.3.0'
+
 
 }
 

--- a/server/src/main/java/net/chatfoodie/server/_core/security/CustomSecurityFilterManager.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/CustomSecurityFilterManager.java
@@ -1,0 +1,11 @@
+package net.chatfoodie.server._core.security;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
+    @Override
+    public void configure(HttpSecurity builder) throws Exception {
+        super.configure(builder);
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/CustomSecurityFilterManager.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/CustomSecurityFilterManager.java
@@ -1,11 +1,14 @@
 package net.chatfoodie.server._core.security;
 
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
 public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
     @Override
     public void configure(HttpSecurity builder) throws Exception {
+        AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+        builder.addFilter(new JwtAuthenticationFilter(authenticationManager));
         super.configure(builder);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/_core/security/CustomUserDetails.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/CustomUserDetails.java
@@ -1,0 +1,49 @@
+package net.chatfoodie.server._core.security;
+
+import net.chatfoodie.server.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public record CustomUserDetails(User user) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<GrantedAuthority> auth = new ArrayList<GrantedAuthority>();
+        auth.add(new SimpleGrantedAuthority("USER"));
+        return auth;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/JwtAuthenticationFilter.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package net.chatfoodie.server._core.security;
+
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server.domain.user.entity.User;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(authenticationManager);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String jwt = request.getHeader(JwtProvider.HEADER);
+
+        if (jwt == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            DecodedJWT decodedJWT = JwtProvider.verify(jwt);
+            Long id = decodedJWT.getClaim("id").asLong();
+            User user = User.builder()
+                    .id(id)
+                    .build();
+            CustomUserDetails userDetails = new CustomUserDetails(user);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            userDetails.getPassword(),
+                            userDetails.getAuthorities()
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("인증 객체 생성됨");
+        } catch (SignatureVerificationException e) {
+            log.error("토큰 검증 실패");
+        } catch (TokenExpiredException e) {
+            log.error("토큰 만료");
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
+
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/JwtProvider.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/JwtProvider.java
@@ -1,0 +1,33 @@
+package net.chatfoodie.server._core.security;
+
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import net.chatfoodie.server.domain.user.entity.User;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+public class JwtProvider {
+    public static final Long EXP = 1000L * 60 * 60 * 48; // 토큰 유효기간 - 테스트 용 48시간
+    public static final String TOKEN_PREFIX = "Bearer "; // 스페이스 필요함
+    public static final String HEADER = "Authorization";
+    public static final String SECRET = "chatFoodie"; // JWT 암호화 핵심 비밀키 배포 전 바꾸고 숨겨야함
+
+    public static String create(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expired = now.plusDays(2);
+        String jwt = JWT.create()
+                .withSubject(user.getLoginId())
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .withClaim("id", user.getId())
+                .sign(Algorithm.HMAC512(SECRET));
+        return TOKEN_PREFIX + jwt;
+    }
+
+    public static DecodedJWT verify(String jwt) {
+        return JWT.require(Algorithm.HMAC512(SECRET)).build()
+                .verify(jwt.replace(TOKEN_PREFIX, ""));
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
@@ -1,0 +1,66 @@
+package net.chatfoodie.server._core.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // 1. CSRF 해제
+        // SSR으로 스프링이 직접 페이지 만들어서 줄때는 csrf를 붙이는게 좋지만 프론트가 분리되어 있다면 그냥 해제하는게 낫다.
+        // Postman 에서 테스트할때도 csrf.disable 을 하지 않으면 에러가 발생한다.
+        http.csrf(AbstractHttpConfigurer::disable); // postman 접근해야 함!! - CSR 할때!!
+
+        // 2. iframe 거부
+        http.headers(headers ->
+                headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+
+        // 3. cors 재설정
+        http.cors(cors ->
+                cors.configurationSource(configurationSource()));
+
+        // 4. jSessionId 가 응답이 될 때 세션영역에서 사라진다(JWT 로 stateless 하게 할거임)
+        http.sessionManagement(management ->
+                management.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 5. form 로그인 해제해서 UsernamePasswordAuthenticationFilter 비활성화 시키기 (Form Post x-www-form-urlencoded)
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // 6. 로그인 인증창이 뜨지 않도록 HttpBasicAuthenticationFilter 비활성화 (헤더에 username, password)
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        // 7. 커스텀 필터들 적용 - 시큐리티 필터 커스텀으로 교체 (필터들을 갈아끼우는 내부 클래스)
+        http.apply(new CustomSecurityFilterManager());
+
+
+        // 8. 인증, 권한 필터 설정
+        http.authorizeHttpRequests(authorize ->
+                        authorize.requestMatchers("/users/**", "/messages/**").authenticated()
+                        .anyRequest().permitAll()
+        );
+
+        return http.build();
+    }
+
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
+        configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 (프론트 앤드 IP만 허용 react)
+        configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
+        configuration.addExposedHeader("Authorization"); // 헤더로 Authorization
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -13,6 +15,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/server/src/main/java/net/chatfoodie/server/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/controller/UserController.java
@@ -1,23 +1,29 @@
 package net.chatfoodie.server.controller;
 
 import lombok.RequiredArgsConstructor;
+import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server.domain.user.dto.UserDto;
-import net.chatfoodie.server.domain.user.service.UserReadService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import net.chatfoodie.server.domain.user.dto.UserRequest;
+import net.chatfoodie.server.domain.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/users")
 public class UserController {
 
-    final private UserReadService userReadService;
+    final private UserService userService;
 
     @GetMapping("/{id}")
     public UserDto getUser(@PathVariable Long id) {
 
-        return userReadService.getUserById(id);
+        return userService.getUserById(id);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(UserRequest.LoginDto requestDto) {
+        String jwt = userService.issueJwtByLogin(requestDto);
+        return ResponseEntity.ok().header(JwtProvider.HEADER, jwt).body("성공");
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/controller/UserController.java
@@ -10,19 +10,24 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/users")
 public class UserController {
 
     final private UserService userService;
 
-    @GetMapping("/{id}")
+    @GetMapping("users/{id}")
     public UserDto getUser(@PathVariable Long id) {
 
         return userService.getUserById(id);
     }
 
+    @PostMapping("/join")
+    public ResponseEntity<String> join(@RequestBody UserRequest.JoinDto requestDto) {
+        userService.join(requestDto);
+        return ResponseEntity.ok().body("success");
+    }
+
     @PostMapping("/login")
-    public ResponseEntity<String> login(UserRequest.LoginDto requestDto) {
+    public ResponseEntity<String> login(@RequestBody UserRequest.LoginDto requestDto) {
         String jwt = userService.issueJwtByLogin(requestDto);
         return ResponseEntity.ok().header(JwtProvider.HEADER, jwt).body("성공");
     }

--- a/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserRequest.java
@@ -1,9 +1,31 @@
 package net.chatfoodie.server.domain.user.dto;
 
+import net.chatfoodie.server.domain.user.entity.User;
+
+import java.time.LocalDate;
+
 public class UserRequest {
-    public  static record LoginDto(
+    public record LoginDto(
        String loginId,
        String password
-    ) {
+    ) {}
+
+    public record JoinDto(
+       String loginId,
+       String password,
+       String name,
+       Boolean gender,
+       LocalDate birth,
+       String email
+    ){
+        public User createUser(String EncodedPassword) {
+            return User.builder()
+                    .loginId(loginId)
+                    .password(EncodedPassword)
+                    .name(name)
+                    .gender(gender)
+                    .birth(birth)
+                    .build();
+        }
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/dto/UserRequest.java
@@ -1,0 +1,9 @@
+package net.chatfoodie.server.domain.user.dto;
+
+public class UserRequest {
+    public  static record LoginDto(
+       String loginId,
+       String password
+    ) {
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
@@ -1,8 +1,6 @@
 package net.chatfoodie.server.domain.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +12,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "user_tb")
 public class User {
     @Id
     @GeneratedValue

--- a/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,27 +16,34 @@ import java.util.Objects;
 @Table(name = "user_tb")
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String login_id;
+    @Column(unique = true, nullable = false, length = 40)
+    private String loginId;
 
+    @Column(nullable = false)
     private String password;
 
+    @ColumnDefault("'회원'")
     private String name;
 
+    @ColumnDefault("0")
     private Boolean gender;
 
+    @ColumnDefault("2000-01-01")
     private LocalDate birth;
+
 
     private String email;
 
+    @ColumnDefault("now()")
     private LocalDateTime created_at;
 
     @Builder
-    public User(Long id, String login_id, String password, String name, Boolean gender, LocalDate birth, String email, LocalDateTime created_at) {
+    public User(Long id, String loginId, String password, String name, Boolean gender, LocalDate birth, String email, LocalDateTime created_at) {
         this.id = id;
-        this.login_id = Objects.requireNonNull(login_id);
+        this.loginId = Objects.requireNonNull(loginId);
         this.password = Objects.requireNonNull(password);
         this.name = name == null ? "회원" : name;
         this.gender = gender == null ? false : gender;

--- a/server/src/main/java/net/chatfoodie/server/domain/user/repository/UserRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/repository/UserRepository.java
@@ -4,6 +4,9 @@ package net.chatfoodie.server.domain.user.repository;
 import net.chatfoodie.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByLoginId(String loginId);
 }

--- a/server/src/main/java/net/chatfoodie/server/domain/user/service/UserReadService.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/service/UserReadService.java
@@ -19,7 +19,7 @@ public class UserReadService {
     private UserDto toDto(User user) {
         return new UserDto(
                 user.getId(),
-                user.getLogin_id(),
+                user.getLoginId(),
                 user.getName(),
                 user.getGender(),
                 user.getBirth(),

--- a/server/src/main/java/net/chatfoodie/server/domain/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/service/UserService.java
@@ -1,19 +1,34 @@
 package net.chatfoodie.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server.domain.user.dto.UserDto;
+import net.chatfoodie.server.domain.user.dto.UserRequest;
 import net.chatfoodie.server.domain.user.entity.User;
 import net.chatfoodie.server.domain.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class UserReadService {
+public class UserService {
+
     final private UserRepository userRepository;
+
+    final private PasswordEncoder passwordEncoder;
 
     public UserDto getUserById(Long id) {
         var user = userRepository.findById(id).orElseThrow();
         return toDto(user);
+    }
+
+    public String issueJwtByLogin(UserRequest.LoginDto requestDto) {
+        User user = userRepository.findByLoginId(requestDto.loginId()).orElseThrow();
+
+        if (passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+            throw new RuntimeException("비밀번호가 틀렸습니다.");
+        }
+        return JwtProvider.create(user);
     }
 
     private UserDto toDto(User user) {

--- a/server/src/main/java/net/chatfoodie/server/domain/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package net.chatfoodie.server.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server.domain.user.dto.UserDto;
 import net.chatfoodie.server.domain.user.dto.UserRequest;
@@ -9,6 +10,7 @@ import net.chatfoodie.server.domain.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class UserService {
@@ -22,10 +24,17 @@ public class UserService {
         return toDto(user);
     }
 
+    public void join(UserRequest.JoinDto requestDto) {
+        // TODO: 중복 체크 필요
+        log.debug(requestDto.toString());
+        String encodedPassword = passwordEncoder.encode(requestDto.password());
+        userRepository.save(requestDto.createUser(encodedPassword));
+    }
+
     public String issueJwtByLogin(UserRequest.LoginDto requestDto) {
         User user = userRepository.findByLoginId(requestDto.loginId()).orElseThrow();
 
-        if (passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+        if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
             throw new RuntimeException("비밀번호가 틀렸습니다.");
         }
         return JwtProvider.create(user);

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -1,0 +1,33 @@
+server:
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true
+  port: 8080
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+      default_batch_fetch_size: 100
+    open-in-view: false
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    '[net.chatfoodie.server]': DEBUG
+    '[org.hibernate.type]': TRACE

--- a/server/src/main/resources/application-product.yml
+++ b/server/src/main/resources/application-product.yml
@@ -1,0 +1,28 @@
+server:
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true
+  port: 8080
+spring:
+  profiles:
+    active:
+      - settings
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+      default_batch_fetch_size: 100
+    open-in-view: false
+
+logging:
+  level:
+    '[net.chatfoodie.server]': INFO
+    '[org.hibernate.type]': TRACE

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,25 +1,4 @@
 spring:
   profiles:
-    include: settings
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQLDialect
-    open-in-view: false
-    defer-datasource-initialization: true
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-        use_sql_comments: true
-        ddl-auto: none
-  sql:
-    init:
-      mode: always
-      schema-locations: classpath:schema.sql
-
-logging:
-  level:
-    org:
-      hibernate: info
+    active:
+      - local


### PR DESCRIPTION
## Summary

오랜만에 대대적으로 바꿨습니다. 

spring의 보안과 관련된 표준 프레임워크인 spring security를 도입시켰습니다.

회원가입 및 로그인(JWT 발급)이 되는 것을 확인하였습니다.

## Description

### 개발용 설정과 배포용 설정의 분리

application.yml을 쪼개 분리 시켰습니다. 개발용에서는 in memory db인 h2를 사용하여 `@Entity`의 내용에 맞게 자동으로 테이블이 자동으로 drop 및 create하도록 하였습니다.

추후 배포 단계에서는 application-product를 사용하여 mysql을 사용하게 됩니다.

문제 발생한 게 테이블 명 `user` 가 예약어로 잡혀 있어 `user_tb`로 변경하였습니다. 다른 Entity도 설정을 전부 맞춰줘야 할 필요가 있습니다. 

### SecurityConfig.java

Security를 위한 기본 세팅인데 커밋 내용 참고 바랍니다.

### 회원가입 로직

`POST /join`으로 들어온 요청에서 body 내용으로 User 만드는데 암호화해서 만듭니다.(passwordEncoder)

passwordEncoder의 경우 SecurityConfig에 Bean으로 IoC 컨테이너에 등록한 PasswordEncoder를 사용합니다.

SecurityConfig.java의 21번째 줄 확인

암호화 알고리즘은 현재 bcrypt 쓴다고 합니다. 자동으로 스프링에서 처리해줍니다.

> [spring security 암호화 정책](https://java.ihoney.pe.kr/498)

### 로그인 로직

```java
if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
    throw new RuntimeException("비밀번호가 틀렸습니다.");
}
```

마찬가지로 passwordEncoder써서 비밀번호 일치 체크 합니다.

