### PR TITLE
이메일 인증 코드를 전송하는 api 구현

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### setting file ###
 application-settings.yml
+application-mail.yml

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/src/main/java/net/chatfoodie/server/_core/config/MailConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/config/MailConfig.java
@@ -1,0 +1,43 @@
+package net.chatfoodie.server._core.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+@Slf4j
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+    @Value("${spring.mail.username}")
+    private String username;
+    @Value("${spring.mail.password}")
+    private String password;
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        return properties;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/EmailVerification.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/EmailVerification.java
@@ -1,0 +1,39 @@
+package net.chatfoodie.server.emailVerification;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "email_verification_tb")
+public class EmailVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false)
+    private String email;
+
+    @Column(length = 10, nullable = false)
+    private String verificationCode;
+
+    @ColumnDefault("now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public EmailVerification(Long id, String email, String verificationCode, LocalDateTime createdAt) {
+        this.id = id;
+        this.email = email;
+        this.verificationCode = verificationCode;
+        this.createdAt = createdAt;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/controller/EmailVerificationController.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/controller/EmailVerificationController.java
@@ -1,0 +1,28 @@
+package net.chatfoodie.server.emailVerification.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import net.chatfoodie.server._core.utils.ApiUtils;
+import net.chatfoodie.server.emailVerification.dto.EmailVerificationRequest;
+import net.chatfoodie.server.emailVerification.service.EmailVerificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class EmailVerificationController {
+    final private EmailVerificationService emailVerificationService;
+
+    @PostMapping("/email-verifications")
+    public ResponseEntity<?> sendVerificationCode(@RequestBody @Valid EmailVerificationRequest.VerificationDto requestDto,
+                                                  Errors errors) {
+        emailVerificationService.sendVerificationCode(requestDto);
+        ApiUtils.Response<?> response = ApiUtils.success();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/dto/EmailVerificationRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/dto/EmailVerificationRequest.java
@@ -1,0 +1,21 @@
+package net.chatfoodie.server.emailVerification.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import net.chatfoodie.server.emailVerification.EmailVerification;
+
+public class EmailVerificationRequest {
+    public record VerificationDto(
+            @NotEmpty @Size(max = 100, message = "최대 100자까지 입니다.")
+            @Pattern(regexp = "^[\\w.%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식이 아닙니다.")
+            String email
+    ) {
+        public EmailVerification createVerification(String verificationCode) {
+            return EmailVerification.builder()
+                    .email(email)
+                    .verificationCode(verificationCode)
+                    .build();
+        }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
@@ -3,8 +3,12 @@ package net.chatfoodie.server.emailVerification.repository;
 import net.chatfoodie.server.emailVerification.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByEmail(String email);
+    Long countByEmailAndCreatedAtBetween(String email, LocalDateTime start, LocalDateTime end);
 }

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
@@ -3,9 +3,7 @@ package net.chatfoodie.server.emailVerification.repository;
 import net.chatfoodie.server.emailVerification.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/repository/EmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package net.chatfoodie.server.emailVerification.repository;
+
+import net.chatfoodie.server.emailVerification.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findByEmail(String email);
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -28,19 +28,18 @@ public class EmailVerificationService {
     public void sendVerificationCode(EmailVerificationRequest.VerificationDto requestDto) {
 
         var existEmailCnt = emailVerificationRepository.countByEmailAndCreatedAtBetween(requestDto.email(), LocalDate.now().atStartOfDay(), LocalDateTime.now());
-        if (existEmailCnt < 5) {
-            var verificationCode = makeCode();
-            var emailVerification = requestDto.createVerification(verificationCode);
 
-            sendEmail(requestDto.email(), verificationCode);
-            try {
-                emailVerificationRepository.save(emailVerification);
-            } catch (Exception e) {
-                throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
-            }
-        }
-        else {
-            throw new Exception400("이메일 인증번호 전송 한도를 초과하였습니다.");
+        if (existEmailCnt >= 5) throw new Exception400("이메일 인증번호 전송 한도를 초과하였습니다.");
+
+        var verificationCode = makeCode();
+        var emailVerification = requestDto.createVerification(verificationCode);
+
+        sendEmail(requestDto.email(), verificationCode);
+
+        try {
+            emailVerificationRepository.save(emailVerification);
+        } catch (Exception e) {
+            throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
         }
     }
 

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -1,6 +1,5 @@
 package net.chatfoodie.server.emailVerification.service;
 
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -29,7 +29,7 @@ public class EmailVerificationService {
 
         var existEmailCnt = emailVerificationRepository.countByEmailAndCreatedAtBetween(requestDto.email(), LocalDate.now().atStartOfDay(), LocalDateTime.now());
 
-        if (existEmailCnt >= 5) throw new Exception400("이메일 인증번호 전송 한도를 초과하였습니다.");
+        if (existEmailCnt >= 5) throw new Exception400("하루 최대 5번까지 인증번호 메일을 요청할 수 있습니다.");
 
         var verificationCode = makeCode();
         var emailVerification = requestDto.createVerification(verificationCode);
@@ -39,7 +39,7 @@ public class EmailVerificationService {
         try {
             emailVerificationRepository.save(emailVerification);
         } catch (Exception e) {
-            throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
+            throw new Exception500("인증 번호 생성 중 오류가 발생했습니다.");
         }
     }
 
@@ -60,7 +60,7 @@ public class EmailVerificationService {
             helper.setText(text, true);
             javaMailSender.send(mimeMessage);
         } catch (Exception e) {
-            throw new Exception500("메일 전송이 한도 초과되었습니다. 내일 다시 시도해주세요.");
+            throw new Exception500("서버 이메일 전송 한도가 초과되었습니다. 내일 다시 시도해주세요.");
         }
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -1,0 +1,68 @@
+package net.chatfoodie.server.emailVerification.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.errors.exception.Exception400;
+import net.chatfoodie.server._core.errors.exception.Exception500;
+import net.chatfoodie.server.emailVerification.dto.EmailVerificationRequest;
+import net.chatfoodie.server.emailVerification.repository.EmailVerificationRepository;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class EmailVerificationService {
+    final private EmailVerificationRepository emailVerificationRepository;
+
+    final private JavaMailSender javaMailSender;
+    @Transactional
+    public void sendVerificationCode(EmailVerificationRequest.VerificationDto requestDto) {
+
+        var existEmailCnt = emailVerificationRepository.countByEmailAndCreatedAtBetween(requestDto.email(), LocalDate.now().atStartOfDay(), LocalDateTime.now());
+        if (existEmailCnt < 5) {
+            var verificationCode = makeCode();
+            var emailVerification = requestDto.createVerification(verificationCode);
+
+            sendEmail(requestDto.email(), verificationCode);
+            try {
+                emailVerificationRepository.save(emailVerification);
+            } catch (Exception e) {
+                throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
+            }
+        }
+        else {
+            throw new Exception400("이메일 인증번호 전송 한도를 초과하였습니다.");
+        }
+    }
+
+    public String makeCode() {
+        Random random = new Random();
+        return String.valueOf(random.nextInt(888888) + 111111);
+    }
+
+    public void sendEmail(String email, String code) {
+        String subject = "chatfoodie 회원가입 인증번호입니다.";
+        String text = "회원가입을 위한 인증번호는 " + code + "입니다. </br>";
+
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
+            helper.setTo(email);
+            helper.setSubject(subject);
+            helper.setText(text, true);
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            throw new Exception500("메일 전송이 한도 초과되었습니다. 내일 다시 시도해주세요.");
+        }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -43,12 +43,12 @@ public class EmailVerificationService {
         }
     }
 
-    public String makeCode() {
+    private String makeCode() {
         Random random = new Random();
         return String.valueOf(random.nextInt(888888) + 111111);
     }
 
-    public void sendEmail(String email, String code) {
+    private void sendEmail(String email, String code) {
         String subject = "chatfoodie 회원가입 인증번호입니다.";
         String text = "회원가입을 위한 인증번호는 " + code + "입니다. </br>";
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   profiles:
     active:
       - local
+      - mail
 
 file:
   path: ./images/


### PR DESCRIPTION
## Summary

이메일 인증 시, 인증 코드를 전송하는 api를 구현하였습니다.

## Description

* 이메일에 인증번호를 보내는 횟수는 하루 5번으로 제한됩니다.
* 추후에 구현할 인증 번호 확인 api를 위해 db에 이메일과 인증코드를 저장합니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #34 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->