### PR TITLE
채팅방 제목 변경 로직 구현

### DIFF
--- a/server/src/main/java/net/chatfoodie/server/chatroom/Chatroom.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/Chatroom.java
@@ -37,4 +37,8 @@ public class Chatroom {
         this.user = user;
         this.createdAt = createdAt;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
@@ -1,15 +1,15 @@
 package net.chatfoodie.server.chatroom.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server._core.utils.ApiUtils;
+import net.chatfoodie.server.chatroom.dto.ChatroomRequest;
 import net.chatfoodie.server.chatroom.service.ChatroomService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,5 +22,15 @@ public class ChatroomController {
         chatroomService.create(userDetails.getId());
         ApiUtils.Response<?> response = ApiUtils.success();
         return ResponseEntity.ok().body(response);
+    }
+
+    @PutMapping("/chatrooms/{chatroomId}")
+    public ResponseEntity<?> changeTitle(@PathVariable Long chatroomId,
+                                         @AuthenticationPrincipal CustomUserDetails userDetails,
+                                         @RequestBody @Valid ChatroomRequest.ChangeTitleDto requestDto,
+                                         Errors errors) {
+        chatroomService.changeTitle(chatroomId, userDetails.getId(), requestDto);
+        ApiUtils.Response<?> response = ApiUtils.success();
+        return ResponseEntity.ok(response);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomRequest.java
@@ -1,4 +1,10 @@
 package net.chatfoodie.server.chatroom.dto;
 
+import jakarta.validation.constraints.Size;
+
 public class ChatroomRequest {
+    public record ChangeTitleDto(
+            @Size(max = 50, message = "최대 50자까지 입니다.")
+            String title
+    ) { }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomRequest.java
@@ -1,9 +1,11 @@
 package net.chatfoodie.server.chatroom.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public class ChatroomRequest {
     public record ChangeTitleDto(
+            @NotNull(message = "제목을 반드시 입력해야 합니다.")
             @Size(max = 50, message = "최대 50자까지 입니다.")
             String title
     ) { }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
@@ -2,6 +2,7 @@ package net.chatfoodie.server.chatroom.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.errors.exception.Exception400;
 import net.chatfoodie.server._core.errors.exception.Exception404;
 import net.chatfoodie.server._core.errors.exception.Exception500;
 import net.chatfoodie.server._core.utils.Utils;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Slf4j
 @Transactional(readOnly = true)
@@ -37,6 +39,17 @@ public class ChatroomService {
             chatroomRepository.save(chatroom);
         } catch (Exception e) {
             throw new Exception500("채팅방 생성 중 오류가 발생하였습니다.");
+        }
+    }
+
+    @Transactional
+    public void changeTitle(Long chatroomId, Long userId, ChatroomRequest.ChangeTitleDto requestDto) {
+        Chatroom chatroom = chatroomRepository.findById(chatroomId).orElseThrow(() -> new Exception404("채팅방을 찾을 수 없습니다."));
+        
+        if (!Objects.equals(chatroom.getUser().getId(), userId)) throw new Exception400("현재 유저의 채팅방이 아닙니다.");
+        
+        if (requestDto.title() != null) {
+            chatroom.updateTitle(requestDto.title());
         }
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
@@ -47,9 +47,7 @@ public class ChatroomService {
         Chatroom chatroom = chatroomRepository.findById(chatroomId).orElseThrow(() -> new Exception404("채팅방을 찾을 수 없습니다."));
         
         if (!Objects.equals(chatroom.getUser().getId(), userId)) throw new Exception400("현재 유저의 채팅방이 아닙니다.");
-        
-        if (requestDto.title() != null) {
-            chatroom.updateTitle(requestDto.title());
-        }
+
+        chatroom.updateTitle(requestDto.title());
     }
 }


### PR DESCRIPTION
## Summary

유저의 채팅방 제목을 바꿀 수 있는 로직을 구현하였습니다.

## Description

- 채팅방이 존재하는지 검사를 합니다.
- 존재하면 지금 로그인한 유저와 채팅방의 유저를 비교합니다.
- 같으면 요청받은 제목으로 업데이트 합니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
close #72 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->