### PR TITLE
WS api/public-chat 구현

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -366,11 +366,12 @@ server of chatFoodie.
         "오리고기, 김치찌개, 생선구이, 들깨나물무침 등이 좋은 저녁 식사가 될 수 있습니다."
       ]
     ],
-    "regenerate" : false,
-    "continue" : false,
+    "regenerate" : false
   }
   ```
-  * `regenerate`와 `continue`를 사용하여 이전 답변 재 생성과 답변 이어서 생성이 가능하다.
+  * `regenerate`를 사용하여 이전 답변 재 생성이 가능하다.
+  * `history`의 길이는 최대 20으로 제한된다.
+  * `input`의 문자열 길이는 최대 500이다.
 
 * Response Messages
   ```json

--- a/server/README.md
+++ b/server/README.md
@@ -398,7 +398,8 @@ server of chatFoodie.
   ```
   ```json
   {
-    "event"  : "stream_end"
+    "event"  : "stream_end",
+    "response": ""
   }
   ```
 

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
@@ -1,0 +1,50 @@
+package net.chatfoodie.server.chat.dto;
+
+import java.util.List;
+
+public class ChatFoodieRequest {
+    public record MessageDto(
+            String user_input,
+            HistoryDto history,
+            Boolean regenerate,
+            Integer max_new_token,
+            String character,
+            String instruction_template,
+            String your_name,
+            Float temperature,
+            Float top_p,
+            Float repetition_penalty,
+            Float top_k,
+            Boolean early_stopping
+    ) {
+
+        public MessageDto(ChatUserRequest.MessageDto userMessageDto) {
+            this(
+                    userMessageDto.input(),
+                    new HistoryDto(userMessageDto.history()),
+                    userMessageDto.regenerate() != null && userMessageDto.regenerate(),
+                    250,
+                    "Example",
+                    "Alpaca",
+                    "회원",
+                    0.7f,
+                    0.9f,
+                    1.15f,
+                    20.0f,
+                    false
+            );
+        }
+
+        record HistoryDto(
+                List<List<String>> internal,
+                List<List<String>> visible
+        ) {
+            public HistoryDto(List<List<String>> userRequestHistory) {
+                this(
+                        userRequestHistory,
+                        userRequestHistory
+                );
+            }
+        }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieResponse.java
@@ -1,0 +1,17 @@
+package net.chatfoodie.server.chat.dto;
+
+import java.util.List;
+
+public class ChatFoodieResponse {
+
+    public record MessageDto(
+            String event,
+            int message_num,
+            HistoryDto history
+    ) {
+        record HistoryDto(
+            List<List<String>> internal,
+            List<List<String>> visible
+        ) { }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
@@ -1,0 +1,19 @@
+package net.chatfoodie.server.chat.dto;
+
+import java.util.List;
+
+public class ChatUserRequest {
+
+    public record MessageDto(
+            String input,
+            List<List<String>> history,
+            Boolean regenerate
+    ) {
+        public boolean validate() {
+            var validInput = input.length() <= 500;
+            var validHistory = history.size() <= 20 && history.stream().allMatch(messagePair -> messagePair.size() == 2);
+            var validRegenerate = regenerate || !input.isEmpty();
+            return validInput && validHistory && validRegenerate;
+        }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserResponse.java
@@ -1,0 +1,21 @@
+package net.chatfoodie.server.chat.dto;
+
+import java.util.Objects;
+
+public class ChatUserResponse {
+
+    public record MessageDto(
+            String event,
+            String response
+    ) {
+        public MessageDto(ChatFoodieResponse.MessageDto foodieMessageDto) {
+            this(
+                    foodieMessageDto.event(),
+                    Objects.equals(foodieMessageDto.event(), "stream_end") ? "":
+                    foodieMessageDto.history().internal()
+                            .get(foodieMessageDto.history().internal().size() - 1)
+                            .get(1)
+            );
+        }
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/FoodieWebSocketHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/FoodieWebSocketHandler.java
@@ -35,7 +35,7 @@ public class FoodieWebSocketHandler extends TextWebSocketHandler {
         return messageQueue.take(); // 큐에서 메시지를 가져옴 (메시지가 없으면 대기)
     }
 
-    private boolean isStreamEndEvent(String message) {
+    public boolean isStreamEndEvent(String message) {
         // 메시지가 JSON 형식인 경우 파싱하여 이벤트를 확인합니다.
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/FoodieWebSocketHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/FoodieWebSocketHandler.java
@@ -1,8 +1,10 @@
 package net.chatfoodie.server.chat.handler;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.chatfoodie.server._core.errors.exception.Exception500;
+import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server.chat.dto.ChatFoodieResponse;
+import net.chatfoodie.server.chat.service.FoodieWebSocketService;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -10,42 +12,38 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+@Slf4j
 public class FoodieWebSocketHandler extends TextWebSocketHandler {
 
-    private final BlockingQueue<String> messageQueue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<ChatFoodieResponse.MessageDto> messageQueue = new LinkedBlockingQueue<>();
+
+    private final ObjectMapper om = new ObjectMapper();
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
             String receivedMessage = message.getPayload();
-            messageQueue.put(receivedMessage); // 받은 메시지를 큐에 추가
-            if (isStreamEndEvent(receivedMessage)) {
+
+            var receivedMessageDto = om.readValue(receivedMessage, ChatFoodieResponse.MessageDto.class);
+
+            messageQueue.put(receivedMessageDto); // 받은 메시지를 큐에 추가
+
+
+            if (FoodieWebSocketService.isStreamEndEvent(receivedMessageDto)) {
                 try {
                     session.close();
                 } catch (Exception e) {
-                    throw new Exception500("챗봇과의 연결을 종료할 수 없습니다.");
+                    log.error("챗봇과의 연결을 종료할 수 없습니다.");
                 }
             }
         } catch (InterruptedException e) {
-            throw new Exception500("챗봇 메시지 처리 중 오류가 발생했습니다");
+            log.error("챗봇 메시지 처리 중 오류가 발생했습니다.");
+        } catch (JsonProcessingException e) {
+            log.error("챗봇으로부터 잘못된 형식의 응답이 들어왔습니다.");
         }
     }
 
-    public String receiveMessage() throws InterruptedException {
+    public ChatFoodieResponse.MessageDto receiveMessage() throws InterruptedException {
         return messageQueue.take(); // 큐에서 메시지를 가져옴 (메시지가 없으면 대기)
-    }
-
-    public boolean isStreamEndEvent(String message) {
-        // 메시지가 JSON 형식인 경우 파싱하여 이벤트를 확인합니다.
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonNode = objectMapper.readTree(message);
-            if (jsonNode.has("event") && "stream_end".equals(jsonNode.get("event").asText())) {
-                return true;
-            }
-        } catch (Exception e) {
-            throw new Exception500("챗봇 응답 오류 입니다.");
-        }
-        return false;
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketHandler.java
@@ -55,10 +55,11 @@ public class UserWebSocketHandler extends TextWebSocketHandler {
         try {
             messageDto = om.readValue(payload, ChatUserRequest.MessageDto.class);
             if (!messageDto.validate()) {
-                throw new RuntimeException("올바른 형식의 메시지가 아닙니다.");
+                log.error("올바른 형식의 메시지가 아닙니다.");
+                throw new RuntimeException();
             }
         } catch (Exception e) {
-            log.info("올바른 형식의 메시지가 아닙니다.");
+            log.error("올바른 형식의 메시지가 아닙니다.");
             session.close();
             return;
         }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketHandler.java
@@ -25,8 +25,6 @@ public class UserWebSocketHandler extends TextWebSocketHandler {
 
     private final Map<WebSocketSession, ChatSessionInfo> chatSessions = new ConcurrentHashMap<>();
 
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-
     private final ObjectMapper om;
 
     @Override
@@ -41,6 +39,7 @@ public class UserWebSocketHandler extends TextWebSocketHandler {
     public UserWebSocketHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
         this.userWebSocketService = userWebSocketService;
         this.om = om;
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         scheduler.scheduleAtFixedRate(this::checkExpiredConnections, 1, 1, TimeUnit.SECONDS);
     }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -13,6 +13,7 @@ import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.*;
 
 
@@ -50,14 +51,11 @@ public class FoodieWebSocketService {
             long startTime = System.currentTimeMillis();
             while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    String message = foodieWebSocketHandler.receiveMessage(); // 메시지를 받음 (메시지가 없으면 대기)
-
-                    var foodieMessageDto = om.readValue(message, ChatFoodieResponse.MessageDto.class);
+                    ChatFoodieResponse.MessageDto foodieMessageDto = foodieWebSocketHandler.receiveMessage(); // 메시지를 받음 (메시지가 없으면 대기)
 
                     var userMessageDto = new ChatUserResponse.MessageDto(foodieMessageDto);
 
                     TextMessage textMessage = new TextMessage(om.writeValueAsString(userMessageDto));
-                    // 메시지 처리 로직 작성
 
                     users.forEach(user -> {
                         try {
@@ -67,7 +65,7 @@ public class FoodieWebSocketService {
                         }
                     });
 
-                    if (foodieWebSocketHandler.isStreamEndEvent(message)) {
+                    if (isStreamEndEvent(foodieMessageDto)) {
                         break;
                     }
                 } catch (InterruptedException e) {
@@ -87,5 +85,9 @@ public class FoodieWebSocketService {
         }
 
         executorService.shutdown();
+    }
+
+    public static boolean isStreamEndEvent(ChatFoodieResponse.MessageDto messageDto) {
+        return Objects.equals(messageDto.event(), "stream_end");
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -44,7 +44,6 @@ public class FoodieWebSocketService {
     public void listenForMessages(List<WebSocketSession> users) {
 
         Future<?> future = executorService.submit(() -> {
-            long startTime = System.currentTimeMillis();
             while (!Thread.currentThread().isInterrupted()) {
                 try {
                     ChatFoodieResponse.MessageDto foodieMessageDto = foodieWebSocketHandler.receiveMessage(); // 메시지를 받음 (메시지가 없으면 대기)

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -35,14 +35,10 @@ public class FoodieWebSocketService {
     }
 
 
-    public void sendMessage(String message) {
-        try {
-            // 서버로 메시지 전송
-            WebSocketSession session = webSocketClient.execute(foodieWebSocketHandler, serverUri).get();
-            session.sendMessage(new TextMessage(message));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+    public void sendMessage(String message) throws Exception {
+        // 서버로 메시지 전송
+        WebSocketSession session = webSocketClient.execute(foodieWebSocketHandler, serverUri).get();
+        session.sendMessage(new TextMessage(message));
     }
 
     public void listenForMessages(List<WebSocketSession> users) {
@@ -61,7 +57,7 @@ public class FoodieWebSocketService {
                         try {
                             user.sendMessage(textMessage);
                         } catch (IOException e) {
-                            log.info("챗봇의 답변 전달 중 오류가 발생했습니다.");
+                            log.error("챗봇의 답변 전달 중 오류가 발생했습니다.");
                         }
                     });
 
@@ -69,9 +65,11 @@ public class FoodieWebSocketService {
                         break;
                     }
                 } catch (InterruptedException e) {
+                    log.error("챗봇의 응답을 듣는 중 에러가 발생했습니다.");
                     Thread.currentThread().interrupt(); // InterruptedException을 받으면 쓰레드 interrupt 상태를 설정하여 종료
                 } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
+                    log.error("챗봇의 응답을 분석하는 중 에러가 발생했습니다.");
+                    Thread.currentThread().interrupt();
                 }
             }
             log.debug("쓰레드 종료됨");
@@ -81,6 +79,7 @@ public class FoodieWebSocketService {
             // 10분 후에 쓰레드 종료
             future.get(10, TimeUnit.MINUTES);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.error("챗봇과의 연결이 10분이 초과되어 강제로 종료합니다.");
             future.cancel(true); // 예외 발생 시 쓰레드 강제 종료
         }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.chatfoodie.server._core.errors.exception.Exception400;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import org.springframework.beans.factory.annotation.Value;

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -1,19 +1,39 @@
 package net.chatfoodie.server.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.errors.exception.Exception400;
+import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
+import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.List;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class UserWebSocketService {
 
     @Value("${chatbot.url}")
     private String serverUri;
 
-    public void requestToFoodie(String messageToSend, List<WebSocketSession> users) {
+    private  final ObjectMapper om;
+
+    public void requestToFoodie(ChatUserRequest.MessageDto userMessageDto, List<WebSocketSession> users) {
         // 메시지를 보내고 응답을 받습니다.
+        var foodieMessageDto = new ChatFoodieRequest.MessageDto(userMessageDto);
+
+        String messageToSend;
+        try {
+            messageToSend = om.writeValueAsString(foodieMessageDto);
+        } catch (JsonProcessingException e) {
+            log.info("챗봇 전달 메시지 변환 중 오류가 발생했습니다.");
+            return;
+        }
 
         FoodieWebSocketService foodieWebSocketService = new FoodieWebSocketService(serverUri);
         foodieWebSocketService.sendMessage(messageToSend);

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -30,12 +31,17 @@ public class UserWebSocketService {
         try {
             messageToSend = om.writeValueAsString(foodieMessageDto);
         } catch (JsonProcessingException e) {
-            log.info("챗봇 전달 메시지 변환 중 오류가 발생했습니다.");
+            log.error("챗봇 전달 메시지 변환 중 오류가 발생했습니다.");
             return;
         }
 
         FoodieWebSocketService foodieWebSocketService = new FoodieWebSocketService(serverUri);
-        foodieWebSocketService.sendMessage(messageToSend);
+        try {
+            foodieWebSocketService.sendMessage(messageToSend);
+        } catch (Exception e) {
+            log.error("챗봇으로 메시지 전송 중 오류가 발생했습니다.");
+            return;
+        }
         foodieWebSocketService.listenForMessages(users);
     }
 }


### PR DESCRIPTION
## Summary

웹소켓 json 형태 메시지를 ObjectMapper를 사용해서 DTO로 변경하여 작업하도록 수정하였습니다.

## Description

    유저의 메시지 -> ChatUserRequest -> ChatFoodieRequest
    -> 챗봇 websocket 서버에 요청 -> 챗봇의 메시지
    -> ChatFoodieResponse -> ChatUserResponse -> json으로 변형하여 유저에게 전달

형태입니다.

추가적으로 유저와의 웹소켓 연결을 시작한지 10분이 지났으면 연결을 끊도록 쓰레드로 타임아웃 걸었습니다.

또한, 챗봇 대답을 기다리는 쓰레드가 while(true)로 삭제되지 않아 유저 요청에 따라 무한히 생기는 버그도 수정하였습니다.

Exception의 경우 단순히 Error log를 남기고 리턴하여 동작을 종료하고 연결을 해제하도록 구현해놓았습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #66 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->