### PR TITLE
채팅방 및 대화 내역 삭제 로직 구현

### DIFF
--- a/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
@@ -41,4 +41,12 @@ public class ChatroomController {
         ApiUtils.Response<?> response = ApiUtils.success();
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/chatrooms/{chatroomId}")
+    public ResponseEntity<?> deleteChatroom(@PathVariable Long chatroomId,
+                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        chatroomService.delete(userDetails.getId(), chatroomId);
+        ApiUtils.Response<?> response = ApiUtils.success();
+        return ResponseEntity.ok(response);
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
@@ -3,5 +3,8 @@ package net.chatfoodie.server.chatroom.message.repository;
 import net.chatfoodie.server.chatroom.message.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
+    void deleteAllByChatroomId(Long chatroomId);
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/repository/ChatroomRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/repository/ChatroomRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
-    List<Chatroom> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Chatroom> findAllByUserIdOrderByIdDesc(Long userId);
 
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
@@ -9,6 +9,8 @@ import net.chatfoodie.server._core.utils.Utils;
 import net.chatfoodie.server.chatroom.Chatroom;
 import net.chatfoodie.server.chatroom.dto.ChatroomRequest;
 import net.chatfoodie.server.chatroom.dto.ChatroomResponse;
+import net.chatfoodie.server.chatroom.message.Message;
+import net.chatfoodie.server.chatroom.message.repository.MessageRepository;
 import net.chatfoodie.server.chatroom.repository.ChatroomRepository;
 import net.chatfoodie.server.user.User;
 import net.chatfoodie.server.user.repository.UserRepository;
@@ -26,6 +28,8 @@ import java.util.Objects;
 public class ChatroomService {
     final private ChatroomRepository chatroomRepository;
     final private UserRepository userRepository;
+    final private MessageRepository messageRepository;
+
     public void create(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new Exception404("회원이 존재하지 않습니다"));
 
@@ -56,5 +60,15 @@ public class ChatroomService {
         if (!Objects.equals(chatroom.getUser().getId(), userId)) throw new Exception400("현재 유저의 채팅방이 아닙니다.");
 
         chatroom.updateTitle(requestDto.title());
+    }
+
+    @Transactional
+    public void delete(Long userId, Long chatroomId) {
+        Chatroom chatroom = chatroomRepository.findById(chatroomId).orElseThrow(() -> new Exception404("채팅방을 찾을 수 없습니다."));
+
+        if (!Objects.equals(userId, chatroom.getUser().getId())) throw new Exception400("현재 유저의 채팅방이 아닙니다.");
+
+        messageRepository.deleteAllByChatroomId(chatroomId);
+        chatroomRepository.delete(chatroom);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
@@ -9,7 +9,6 @@ import net.chatfoodie.server._core.utils.Utils;
 import net.chatfoodie.server.chatroom.Chatroom;
 import net.chatfoodie.server.chatroom.dto.ChatroomRequest;
 import net.chatfoodie.server.chatroom.dto.ChatroomResponse;
-import net.chatfoodie.server.chatroom.message.Message;
 import net.chatfoodie.server.chatroom.message.repository.MessageRepository;
 import net.chatfoodie.server.chatroom.repository.ChatroomRepository;
 import net.chatfoodie.server.user.User;
@@ -48,7 +47,7 @@ public class ChatroomService {
     }
 
     public ChatroomResponse.GetChatroomDto get(Long userId) {
-        List<Chatroom> chatrooms = chatroomRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        List<Chatroom> chatrooms = chatroomRepository.findAllByUserIdOrderByIdDesc(userId);
 
         return ChatroomResponse.GetChatroomDto.of(chatrooms);
     }

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -79,3 +79,15 @@ VALUES ('test', '{bcrypt}$2a$10$iRfOSldsM6yVzqGfsQNF5u1Fq8g85xFt.k/DPldr1jVk3rds
 INSERT INTO favor_tb (user_id, food_id)
 VALUES (1, 1),
        (1, 2);
+
+INSERT INTO chatroom_tb (title, user_id)
+VALUES ('아침 추천', 1),
+       ('매운 음식 추천', 1);
+
+INSERT INTO message_tb (chatroom_id, is_from_chatbot, content)
+VALUES (1, false, '아침 메뉴 추천해줘'),
+       (1, true, '건강한 아침을 위해 그릭 요거트에 견과류와 과일을 넣고 오트밀과 함께 즐겨보세요!'),
+       (1, false, '밥 요리로 추천해줘'),
+       (1, true, '달걀 볶음밥을 만들어보세요. 신선한 야채와 함께 볶은 밥에 계란을 섞어 풍미를 더하고, 간장 또는 고추장으로 맛을 조절해보세요!'),
+       (2, false, '매운 음식 추천해줘'),
+       (2, true, '매운 맛을 즐기고 싶다면 "양념 불고기"를 추천드려요. 소고기를 매운 양념과 함께 볶아내어 매콤하고 풍미 있는 한식 요리를 즐겨보세요!');


### PR DESCRIPTION
## Summary

유저가 선택한 채팅방의 메시지와 채팅방을 삭제하는 로직을 구현했습니다.


## Description

* api의 주소로 온 채팅방 아이디를 이용하여 채팅방을 조회합니다.
* 조회한 채팅방의 유저 아이디와 요청한 유저 아이디를 비교합니다.
* 유저 본인의 채팅방이 맞다면 대화 내역과 채팅방을 삭제합니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #74 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->