### PR TITLE
회원용 웹소켓 채팅 구현 및 디자인 패턴 적용

### DIFF
--- a/server/src/main/java/net/chatfoodie/server/_core/config/WebSocketConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/config/WebSocketConfig.java
@@ -1,7 +1,9 @@
 package net.chatfoodie.server._core.config;
 
 import lombok.RequiredArgsConstructor;
-import net.chatfoodie.server.chat.handler.UserWebSocketHandler;
+import net.chatfoodie.server.chat.handler.UserWebSocketApiHandler;
+import net.chatfoodie.server.chat.handler.UserWebSocketBaseHandler;
+import net.chatfoodie.server.chat.handler.UserWebSocketPublicApiHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -12,12 +14,14 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @EnableWebSocket
 public class WebSocketConfig implements WebSocketConfigurer {
 
-    private final UserWebSocketHandler userWebSocketHandler;
+    private final UserWebSocketApiHandler userWebSocketApiHandler;
+
+    private final UserWebSocketPublicApiHandler userWebSocketPublicApiHandler;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(userWebSocketHandler, "/api/chat")
-                .addHandler(userWebSocketHandler, "/api/public-chat")
+        registry.addHandler(userWebSocketApiHandler, "/api/chat")
+                .addHandler(userWebSocketPublicApiHandler, "/api/public-chat")
                 .setAllowedOrigins(Configs.CORS.toArray(new String[0])); // CORS 허용
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/_core/security/CustomUserDetails.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/CustomUserDetails.java
@@ -21,10 +21,6 @@ public record CustomUserDetails(User user) implements UserDetails {
         return user.getId();
     }
 
-    public String getLoginId() {
-        return user.getLoginId();
-    }
-
     @Override
     public String getPassword() {
         return user.getPassword();

--- a/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
@@ -1,0 +1,6 @@
+package net.chatfoodie.server._core.utils;
+
+@FunctionalInterface
+public interface MyFunction {
+    void apply(String message);
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/ChatSessionInfo.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/ChatSessionInfo.java
@@ -1,0 +1,13 @@
+package net.chatfoodie.server.chat;
+
+public record ChatSessionInfo(
+        String chatSessionId,
+        Long expirationTime
+) {
+    private static final Long connectionTimeout = 10 * 60 * 1000L; // 10m
+
+    public ChatSessionInfo(String chatRoomId) {
+        this(chatRoomId, System.currentTimeMillis() + connectionTimeout);
+    }
+
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
@@ -35,6 +35,23 @@ public class ChatFoodieRequest {
             );
         }
 
+        public MessageDto(ChatUserRequest.MessageDto userMessageDto, List<List<String>> history, String userName) {
+            this(
+                    userMessageDto.input(),
+                    new HistoryDto(history),
+                    userMessageDto.regenerate() != null && userMessageDto.regenerate(),
+                    250,
+                    "Example",
+                    "Alpaca",
+                    userName,
+                    0.7f,
+                    0.9f,
+                    1.15f,
+                    20.0f,
+                    false
+            );
+        }
+
         record HistoryDto(
                 List<List<String>> internal,
                 List<List<String>> visible

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
@@ -18,11 +18,11 @@ public class ChatFoodieRequest {
             Boolean early_stopping
     ) {
 
-        public MessageDto(ChatUserRequest.MessageDto userMessageDto) {
+        public MessageDto(ChatUserRequest.PublicMessageDto userPublicMessageDto) {
             this(
-                    userMessageDto.input(),
-                    new HistoryDto(userMessageDto.history()),
-                    userMessageDto.regenerate() != null && userMessageDto.regenerate(),
+                    userPublicMessageDto.input(),
+                    new HistoryDto(userPublicMessageDto.history()),
+                    userPublicMessageDto.regenerate() != null && userPublicMessageDto.regenerate(),
                     250,
                     "Example",
                     "Alpaca",

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
@@ -3,6 +3,16 @@ package net.chatfoodie.server.chat.dto;
 import java.util.List;
 
 public class ChatFoodieRequest {
+
+    private static final Integer MAX_NEW_TOKEN = 250;
+    private static final String CHARACTER = "Example";
+    private static final String INSTRUCTION_TEMPLATE = "Alpaca";
+    private static final Float TEMPERATURE = 0.7f;
+    private static final Float TOP_P = 0.9f;
+    private static final Float REPETITION_PENALTY = 1.15f;
+    private static final Float TOP_K = 20.0f;
+    private static final Boolean EARLY_STOPPING = false;
+
     public record MessageDto(
             String user_input,
             HistoryDto history,
@@ -23,15 +33,15 @@ public class ChatFoodieRequest {
                     userPublicMessageDto.input(),
                     new HistoryDto(userPublicMessageDto.history()),
                     userPublicMessageDto.regenerate() != null && userPublicMessageDto.regenerate(),
-                    250,
-                    "Example",
-                    "Alpaca",
+                    MAX_NEW_TOKEN,
+                    CHARACTER,
+                    INSTRUCTION_TEMPLATE,
                     "회원",
-                    0.7f,
-                    0.9f,
-                    1.15f,
-                    20.0f,
-                    false
+                    TEMPERATURE,
+                    TOP_P,
+                    REPETITION_PENALTY,
+                    TOP_K,
+                    EARLY_STOPPING
             );
         }
 
@@ -40,15 +50,15 @@ public class ChatFoodieRequest {
                     userMessageDto.input(),
                     new HistoryDto(history),
                     userMessageDto.regenerate() != null && userMessageDto.regenerate(),
-                    250,
-                    "Example",
-                    "Alpaca",
+                    MAX_NEW_TOKEN,
+                    CHARACTER,
+                    INSTRUCTION_TEMPLATE,
                     userName,
-                    0.7f,
-                    0.9f,
-                    1.15f,
-                    20.0f,
-                    false
+                    TEMPERATURE,
+                    TOP_P,
+                    REPETITION_PENALTY,
+                    TOP_K,
+                    EARLY_STOPPING
             );
         }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
@@ -4,16 +4,28 @@ import java.util.List;
 
 public class ChatUserRequest {
 
-    public record MessageDto(
+    public record PublicMessageDto(
             String input,
             List<List<String>> history,
             Boolean regenerate
     ) {
-        public boolean validate() {
+        public boolean notValidate() {
             var validInput = input.length() <= 500;
             var validHistory = history.size() <= 20 && history.stream().allMatch(messagePair -> messagePair.size() == 2);
             var validRegenerate = regenerate || !input.isEmpty();
-            return validInput && validHistory && validRegenerate;
+            return !validInput || !validHistory || !validRegenerate;
+        }
+    }
+
+    public record MessageDto(
+            String input,
+            Long chatroomId,
+            Boolean regenerate
+    ) {
+        public boolean notValidate() {
+            var validInput = input.length() <= 500;
+            var validRegenerate = regenerate || !input.isEmpty();
+            return !validInput || !validRegenerate;
         }
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserRequest.java
@@ -4,11 +4,15 @@ import java.util.List;
 
 public class ChatUserRequest {
 
-    public record PublicMessageDto(
+    public interface MessageDtoInterface{
+        public boolean notValidate();
+    };
+
+    public record PublicMessageDto (
             String input,
             List<List<String>> history,
             Boolean regenerate
-    ) {
+    ) implements MessageDtoInterface{
         public boolean notValidate() {
             var validInput = input.length() <= 500;
             var validHistory = history.size() <= 20 && history.stream().allMatch(messagePair -> messagePair.size() == 2);
@@ -21,7 +25,7 @@ public class ChatUserRequest {
             String input,
             Long chatroomId,
             Boolean regenerate
-    ) {
+    ) implements MessageDtoInterface{
         public boolean notValidate() {
             var validInput = input.length() <= 500;
             var validRegenerate = regenerate || !input.isEmpty();

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -1,84 +1,44 @@
 package net.chatfoodie.server.chat.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.errors.exception.Exception401;
 import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import net.chatfoodie.server.chat.service.UserWebSocketService;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.CloseStatus;
-import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.Objects;
+import java.io.IOException;
 
 @Slf4j
 @Component
 public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
-    @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        super.afterConnectionEstablished(session);
-    }
 
     public UserWebSocketApiHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
         super(userWebSocketService, om);
     }
+    @Override
+    protected ChatUserRequest.MessageDtoInterface toMessageDto(String payload) throws JsonProcessingException {
+        return om.readValue(payload, ChatUserRequest.MessageDto.class);
+    }
 
     @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        String payload = message.getPayload();
-        log.info("받은 메시지 : " + payload);
-
-        // Object 로 매핑
-        ChatUserRequest.MessageDto messageDto;
-        try {
-            messageDto = om.readValue(payload, ChatUserRequest.MessageDto.class);
-            if (messageDto.notValidate()) {
-                log.error("올바른 형식의 메시지가 아닙니다.");
-                throw new RuntimeException();
-            }
-        } catch (Exception e) {
-            log.error("올바른 형식의 메시지가 아닙니다.");
-            session.close();
-            return;
-        }
-
-
+    protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
         Authentication authentication = (Authentication) session.getPrincipal();
 
         if (authentication == null) {
-            log.error("인증 정보가 없는 접근입니다.");
-            session.close();
-            return;
+            throw new RuntimeException();
         }
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
         Long userId = customUserDetails.getId();
 
-
-        ChatFoodieRequest.MessageDto foodieMessageDto;
-        try {
-            foodieMessageDto = userWebSocketService.toFoodieRequestDto(messageDto, userId);
-        } catch (Exception e) {
-            log.error("잘못된 입력입니다.");
-            session.close();
-            return;
-        }
-
-        String chatSessionId = chatSessions.get(session).chatSessionId();
-        var users = chatSessions.keySet().stream()
-                .filter(s -> chatSessions.get(s).chatSessionId().equals(chatSessionId))
-                .toList();
-
-
-
-        userWebSocketService.requestToFoodie(foodieMessageDto, users);
-    }
-
-    @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        super.afterConnectionClosed(session, status);
+        return userWebSocketService.toFoodieRequestDto(
+                (ChatUserRequest.MessageDto) messageDto, userId
+        );
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -1,0 +1,33 @@
+package net.chatfoodie.server.chat.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server.chat.dto.ChatUserRequest;
+import net.chatfoodie.server.chat.service.UserWebSocketService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+@Slf4j
+@Component
+public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        super.afterConnectionEstablished(session);
+    }
+
+    public UserWebSocketApiHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
+        super(userWebSocketService, om);
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        super.handleTextMessage(session, message);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        super.afterConnectionClosed(session, status);
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -3,11 +3,9 @@ package net.chatfoodie.server.chat.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import net.chatfoodie.server.chat.service.UserWebSocketService;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -25,18 +23,16 @@ public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
 
     @Override
     protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
-        Authentication authentication = (Authentication) session.getPrincipal();
-
-        if (authentication == null) {
-            throw new RuntimeException();
-        }
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-
-        Long userId = customUserDetails.getId();
-
+        Long userId = userWebSocketService.getUserId(session);
 
         return userWebSocketService.makeFoodieRequestDto(
                 (ChatUserRequest.MessageDto) messageDto, userId
         );
+    }
+
+    @Override
+    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) {
+        var userMessageDto = (ChatUserRequest.MessageDto) messageDtoInterface;
+        userWebSocketService.requestToFoodie(foodieMessageDto, session, userMessageDto.chatroomId());
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -2,12 +2,17 @@ package net.chatfoodie.server.chat.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.security.CustomUserDetails;
+import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import net.chatfoodie.server.chat.service.UserWebSocketService;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -23,7 +28,53 @@ public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        super.handleTextMessage(session, message);
+        String payload = message.getPayload();
+        log.info("받은 메시지 : " + payload);
+
+        // Object 로 매핑
+        ChatUserRequest.MessageDto messageDto;
+        try {
+            messageDto = om.readValue(payload, ChatUserRequest.MessageDto.class);
+            if (messageDto.notValidate()) {
+                log.error("올바른 형식의 메시지가 아닙니다.");
+                throw new RuntimeException();
+            }
+        } catch (Exception e) {
+            log.error("올바른 형식의 메시지가 아닙니다.");
+            session.close();
+            return;
+        }
+
+
+        Authentication authentication = (Authentication) session.getPrincipal();
+
+        if (authentication == null) {
+            log.error("인증 정보가 없는 접근입니다.");
+            session.close();
+            return;
+        }
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        Long userId = customUserDetails.getId();
+
+
+        ChatFoodieRequest.MessageDto foodieMessageDto;
+        try {
+            foodieMessageDto = userWebSocketService.toFoodieRequestDto(messageDto, userId);
+        } catch (Exception e) {
+            log.error("잘못된 입력입니다.");
+            session.close();
+            return;
+        }
+
+        String chatSessionId = chatSessions.get(session).chatSessionId();
+        var users = chatSessions.keySet().stream()
+                .filter(s -> chatSessions.get(s).chatSessionId().equals(chatSessionId))
+                .toList();
+
+
+
+        userWebSocketService.requestToFoodie(foodieMessageDto, users);
     }
 
     @Override

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -3,7 +3,6 @@ package net.chatfoodie.server.chat.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import net.chatfoodie.server._core.errors.exception.Exception401;
 import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
@@ -11,8 +10,6 @@ import net.chatfoodie.server.chat.service.UserWebSocketService;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
-
-import java.io.IOException;
 
 @Slf4j
 @Component
@@ -37,7 +34,8 @@ public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
 
         Long userId = customUserDetails.getId();
 
-        return userWebSocketService.toFoodieRequestDto(
+
+        return userWebSocketService.makeFoodieRequestDto(
                 (ChatUserRequest.MessageDto) messageDto, userId
         );
     }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
@@ -3,7 +3,6 @@ package net.chatfoodie.server.chat.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import net.chatfoodie.server._core.errors.exception.Exception401;
 import net.chatfoodie.server.chat.ChatSessionInfo;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
@@ -54,10 +53,10 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
         log.info("받은 메시지 : " + payload);
 
         // Object 로 매핑
-        ChatUserRequest.MessageDtoInterface publicMessageDto;
+        ChatUserRequest.MessageDtoInterface messageDtoInterface;
         try {
-            publicMessageDto = toMessageDto(payload);
-            if (publicMessageDto.notValidate()) {
+            messageDtoInterface = toMessageDto(payload);
+            if (messageDtoInterface.notValidate()) {
                 log.error("올바른 형식의 메시지가 아닙니다.");
                 throw new RuntimeException();
             }
@@ -69,14 +68,14 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
 
         ChatFoodieRequest.MessageDto foodieMessageDto;
         try {
-            foodieMessageDto = toFoodieMessageDto(publicMessageDto, session);
+            foodieMessageDto = toFoodieMessageDto(messageDtoInterface, session);
         } catch (Exception e) {
             log.error("잘못된 입력입니다.");
             session.close();
             return;
         }
 
-        userWebSocketService.requestToFoodie(foodieMessageDto, session);
+        requestToFoodie(messageDtoInterface, foodieMessageDto, session);
     }
 
     protected abstract ChatUserRequest.MessageDtoInterface toMessageDto(String payload) throws JsonProcessingException;
@@ -84,7 +83,7 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
 
     protected abstract ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session);
 
-
+    protected abstract void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session);
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
@@ -65,12 +65,14 @@ public class UserWebSocketBaseHandler extends TextWebSocketHandler {
             return;
         }
 
+        var foodieMessageDto = userWebSocketService.toFoodieRequestDto(publicMessageDto);
+
         String chatSessionId = chatSessions.get(session).chatSessionId();
         var users = chatSessions.keySet().stream()
                 .filter(s -> chatSessions.get(s).chatSessionId().equals(chatSessionId))
                 .toList();
 
-        userWebSocketService.requestToFoodie(publicMessageDto, users);
+        userWebSocketService.requestToFoodie(foodieMessageDto, users);
     }
 
     @Override

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -1,0 +1,13 @@
+package net.chatfoodie.server.chat.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.chatfoodie.server.chat.service.UserWebSocketService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
+
+    public UserWebSocketPublicApiHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
+        super(userWebSocketService, om);
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -22,7 +22,12 @@ public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
 
     @Override
     protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
-        // TODO: pulbic-chat의 경우 하루 요청가능 횟수 제한 필요
+
         return new ChatFoodieRequest.MessageDto((ChatUserRequest.PublicMessageDto) messageDto);
+    }
+
+    @Override
+    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) {
+        userWebSocketService.requestToFoodiePublic(foodieMessageDto, session);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -1,13 +1,28 @@
 package net.chatfoodie.server.chat.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
+import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import net.chatfoodie.server.chat.service.UserWebSocketService;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
 
 @Component
 public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
 
     public UserWebSocketPublicApiHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
         super(userWebSocketService, om);
+    }
+
+    @Override
+    protected ChatUserRequest.MessageDtoInterface toMessageDto(String payload) throws JsonProcessingException {
+        return om.readValue(payload, ChatUserRequest.PublicMessageDto.class);
+    }
+
+    @Override
+    protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
+        // TODO: pulbic-chat의 경우 하루 요청가능 횟수 제한 필요
+        return userWebSocketService.toFoodieRequestDto((ChatUserRequest.PublicMessageDto)messageDto);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -23,6 +23,6 @@ public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
     @Override
     protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
         // TODO: pulbic-chat의 경우 하루 요청가능 횟수 제한 필요
-        return userWebSocketService.toFoodieRequestDto((ChatUserRequest.PublicMessageDto)messageDto);
+        return new ChatFoodieRequest.MessageDto((ChatUserRequest.PublicMessageDto) messageDto);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -38,6 +38,7 @@ public class FoodieWebSocketService {
     public void sendMessage(String message) throws Exception {
         // 서버로 메시지 전송
         WebSocketSession session = webSocketClient.execute(foodieWebSocketHandler, serverUri).get();
+        log.info("챗봇으로의 보낼 메시지:" + message);
         session.sendMessage(new TextMessage(message));
     }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -42,7 +42,7 @@ public class FoodieWebSocketService {
         session.sendMessage(new TextMessage(message));
     }
 
-    public void listenForMessages(List<WebSocketSession> users) {
+    public void listenForMessages(WebSocketSession user) {
 
         Future<?> future = executorService.submit(() -> {
             while (!Thread.currentThread().isInterrupted()) {
@@ -53,13 +53,7 @@ public class FoodieWebSocketService {
 
                     TextMessage textMessage = new TextMessage(om.writeValueAsString(userMessageDto));
 
-                    users.forEach(user -> {
-                        try {
-                            user.sendMessage(textMessage);
-                        } catch (IOException e) {
-                            log.error("챗봇의 답변 전달 중 오류가 발생했습니다.");
-                        }
-                    });
+                    user.sendMessage(textMessage);
 
                     if (isStreamEndEvent(foodieMessageDto)) {
                         break;
@@ -70,6 +64,9 @@ public class FoodieWebSocketService {
                 } catch (JsonProcessingException e) {
                     log.error("챗봇의 응답을 분석하는 중 에러가 발생했습니다.");
                     Thread.currentThread().interrupt();
+                } catch (IOException e) {
+                    log.error("챗봇의 답변 전달 중 오류가 발생했습니다.");
+                    throw new RuntimeException(e);
                 }
             }
             log.debug("쓰레드 종료됨");

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -114,6 +114,8 @@ public class UserWebSocketService {
             throw new Exception403("권한이 없는 채팅방입니다.");
 
         var messages = messageRepository.findTop38ByChatroomIdOrderByIdDesc(userMessageDto.chatroomId());
+
+        // TODO: 맨 앞에 선호도 채팅을 추가하기!!!
         var history = makeHistoryFromMessages(messages);
         return new ChatFoodieRequest.MessageDto(userMessageDto, history, chatroom.getUser().getName());
     }

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -60,13 +60,8 @@ public class UserWebSocketService {
         foodieWebSocketService.listenForMessages(user);
     }
 
-    public ChatFoodieRequest.MessageDto toFoodieRequestDto(ChatUserRequest.PublicMessageDto userPublicMessageDto) {
-        return new ChatFoodieRequest.MessageDto(userPublicMessageDto);
-    }
-
-
     @Transactional
-    public ChatFoodieRequest.MessageDto toFoodieRequestDto(ChatUserRequest.MessageDto userMessageDto, Long userId) {
+    public ChatFoodieRequest.MessageDto makeFoodieRequestDto(ChatUserRequest.MessageDto userMessageDto, Long userId) {
 
         Chatroom chatroom = chatroomRepository.findByIdJoinUser(userMessageDto.chatroomId())
                 .orElseThrow(() -> new Exception404("존재하지 않는 채팅방입니다."));
@@ -75,11 +70,11 @@ public class UserWebSocketService {
             throw new Exception403("권한이 없는 채팅방입니다.");
 
         var messages = messageRepository.findTop38ByChatroomIdOrderByIdDesc(userMessageDto.chatroomId());
-        var history = toHistoryFromMessages(messages);
+        var history = makeHistoryFromMessages(messages);
         return new ChatFoodieRequest.MessageDto(userMessageDto, history, chatroom.getUser().getName());
     }
 
-    private List<List<String>> toHistoryFromMessages(List<Message> messages) {
+    private List<List<String>> makeHistoryFromMessages(List<Message> messages) {
         List<String> reversedMessages = new ArrayList<>();
 
         for (Message message : messages) {

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -23,9 +22,9 @@ public class UserWebSocketService {
 
     private  final ObjectMapper om;
 
-    public void requestToFoodie(ChatUserRequest.MessageDto userMessageDto, List<WebSocketSession> users) {
+    public void requestToFoodie(ChatUserRequest.PublicMessageDto userPublicMessageDto, List<WebSocketSession> users) {
         // 메시지를 보내고 응답을 받습니다.
-        var foodieMessageDto = new ChatFoodieRequest.MessageDto(userMessageDto);
+        var foodieMessageDto = new ChatFoodieRequest.MessageDto(userPublicMessageDto);
 
         String messageToSend;
         try {

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -39,7 +39,7 @@ public class UserWebSocketService {
 
     private final ChatroomRepository chatroomRepository;
 
-    public void requestToFoodie( ChatFoodieRequest.MessageDto foodieMessageDto, List<WebSocketSession> users) {
+    public void requestToFoodie( ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession user) {
         // 메시지를 보내고 응답을 받습니다.
 
         String messageToSend;
@@ -57,7 +57,7 @@ public class UserWebSocketService {
             log.error("챗봇으로 메시지 전송 중 오류가 발생했습니다.");
             return;
         }
-        foodieWebSocketService.listenForMessages(users);
+        foodieWebSocketService.listenForMessages(user);
     }
 
     public ChatFoodieRequest.MessageDto toFoodieRequestDto(ChatUserRequest.PublicMessageDto userPublicMessageDto) {

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
@@ -29,5 +29,5 @@ public class Message {
     private String content;
 
     @ColumnDefault(value = "now()")
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
@@ -2,6 +2,7 @@ package net.chatfoodie.server.chatroom.message;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.chatfoodie.server.chatroom.Chatroom;
@@ -30,4 +31,13 @@ public class Message {
 
     @ColumnDefault(value = "now()")
     private LocalDateTime createdAt;
+
+    @Builder
+    public Message(Long id, Chatroom chatroom, boolean isFromChatbot, String content, LocalDateTime createdAt) {
+        this.id = id;
+        this.chatroom = chatroom;
+        this.isFromChatbot = isFromChatbot;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
@@ -40,4 +40,8 @@ public class Message {
         this.content = content;
         this.createdAt = createdAt;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
@@ -4,9 +4,12 @@ import net.chatfoodie.server.chatroom.message.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     void deleteAllByChatroomId(Long chatroomId);
 
     List<Message> findTop38ByChatroomIdOrderByIdDesc(Long chatroomId);
+
+    Optional<Message> findTop1ByChatroomIdOrderByIdDesc(Long chatroomId);
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/repository/MessageRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
     void deleteAllByChatroomId(Long chatroomId);
+
+    List<Message> findTop38ByChatroomIdOrderByIdDesc(Long chatroomId);
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/repository/ChatroomRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/repository/ChatroomRepository.java
@@ -2,10 +2,15 @@ package net.chatfoodie.server.chatroom.repository;
 
 import net.chatfoodie.server.chatroom.Chatroom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
     List<Chatroom> findAllByUserIdOrderByIdDesc(Long userId);
+
+    @Query("SELECT c FROM Chatroom c JOIN FETCH c.user u WHERE c.id=:id")
+    Optional<Chatroom> findByIdJoinUser(Long id);
 
 }


### PR DESCRIPTION
## Summary

기본적인 웹소켓 구상이 전부 끝낸 것 같습니다. 채팅 저장도 잘되고 채팅도 이어서 잘됩니다.

비회원의 경우 메시지 저장 및 ip 수집으로 횟수 제한 하는 부분만 //TODO 부분에 작성하면 될 거 같습니다.

아직 선호도는 추가안했습니다.(TODO로 되어 있음)

## Description

먼저 `UserWebSocketHandler`로 통일 되있던 걸 추상 클래스 `UserWebSocketBaseHandler`를 상속하는 2개의 구현 클래스로 분리했습니다. `UserWebSocketBaseHandler`는 템플릿 메소드 패턴을 적용해서 기본 동작은 추상 클래스에 전부 있고 두 클래스의 달라지는 부분만 직접 구현하면 동작하도록 했습니다. `RequestDto`는 `MessageDtoInterface`로 다형성을 사용해 처리했습니다. 

`listenForMessages`에서 마지막 챗봇 응답이 와서 응답 메시지가 완성됐을 때 저장해야해서 함수형 프로그래밍으로 함수를 함수를 인자에 전달해 각각의 동작을 시키는 방식으로 구현했습니다. 추후 public-chat에 기능 추가할때 그대로 쓰면 됩니다.

서버에 디버깅 용 로그도 많이 남겨놨는데 한번 실행해보고 보시면 좋을 거 같습니다.

## 실행

메인 페이지에 있는 colab 노트북 켜서 전체 셀 실행하고 wss 주소 application-yml에 붙여넣기 하고 서버 켜면 실행됩니다.

포스트맨으로 `ws://localhost:8080/api/chat` 에다 

![image](https://github.com/jagaldol/chat-foodie/assets/84557643/7bd37661-1bd7-4af2-b9f0-047b905c0e42)

사진 처럼 헤더에 Authorization해서 로그인 후 나오는 토큰 집어넣고 실행하면 됩니다.

```json
{
  "input" : "오늘의 점심밥을 추천해줘",
  "chatroomId": 1,
  "regenerate" : false
}
```

보내면 응답 나오고 이전 대화는 서버에서 자동으로 확인하여 챗봇에 전달됩니다. 대화는 최대 19쌍 기억됩니다.

![image](https://github.com/jagaldol/chat-foodie/assets/84557643/2e3eb81f-b093-480a-a8cb-e73578dde1e7)

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #68 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->