### PR TITLE
웹소켓 기본 기능 전부 구현

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -352,7 +352,7 @@ server of chatFoodie.
 
 (비회원 메서드)사용자의 입력을 전달하고 답변을 스트리밍으로 돌려 받음
 
-하루에 메시지 생성 가능 횟수 제한
+하루에 메시지 생성 가능 횟수 제한(20회)
 
 * Request Message
   ```json
@@ -405,6 +405,14 @@ server of chatFoodie.
   }
   ```
 
+* Error의 경우(프론트에서 event에 error인 경우 alert 창으로 경고문 전송 처리할 것)
+  ```json
+  {
+    "event": "error",
+    "response": "일일 최대 횟수에 도달했습니다."
+  }
+  ```
+
 ### WebSocket /api/chat
 
 (회원 전용 메서드)사용자의 입력을 전달하고 답변을 스트리밍으로 돌려 받음
@@ -419,11 +427,10 @@ server of chatFoodie.
   {
     "input" : "피자 때문에 배가 아픈데 속이 편한 음식을 알려줘",
     "chatroomId" : 1,
-    "regenerate" : false,
-    "continue" : false,
+    "regenerate" : false
   }
   ```
-  * `regenerate`와 `continue`를 사용하여 이전 답변 재 생성과 답변 이어서 생성이 가능하다.
+  * `regenerate`를 사용하여 이전 답변 재 생성이 가능하다.
 
 * Response Messages
   ```json

--- a/server/src/main/java/net/chatfoodie/server/_core/config/WebSocketConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/config/WebSocketConfig.java
@@ -2,7 +2,6 @@ package net.chatfoodie.server._core.config;
 
 import lombok.RequiredArgsConstructor;
 import net.chatfoodie.server.chat.handler.UserWebSocketApiHandler;
-import net.chatfoodie.server.chat.handler.UserWebSocketBaseHandler;
 import net.chatfoodie.server.chat.handler.UserWebSocketPublicApiHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -9,6 +9,8 @@ import net.chatfoodie.server.chat.service.UserWebSocketService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.io.IOException;
+
 @Slf4j
 @Component
 public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
@@ -31,7 +33,7 @@ public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
     }
 
     @Override
-    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) {
+    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) throws IOException {
         var userMessageDto = (ChatUserRequest.MessageDto) messageDtoInterface;
         userWebSocketService.requestToFoodie(foodieMessageDto, session, userMessageDto.chatroomId());
     }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
@@ -80,13 +80,12 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
             requestToFoodie(messageDtoInterface, foodieMessageDto, session);
         } catch (Exception500 | Exception400 e) {
             session.sendMessage(userWebSocketService.createErrorMessage(e.getMessage()));
-            session.close();
         } catch (JsonProcessingException e) {
             session.sendMessage(userWebSocketService.createErrorMessage("메시지 변환 중 오류가 발생했습니다."));
-            session.close();
         } catch (Exception e) {
             session.sendMessage(userWebSocketService.createErrorMessage("챗봇에게 요청 중 오류가 발생했습니다."));
-            session.close();
+        } finally {
+            session.close(); // 자동 세션 종료 시켜줌
         }
     }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
@@ -3,6 +3,8 @@ package net.chatfoodie.server.chat.handler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.errors.exception.Exception400;
+import net.chatfoodie.server._core.errors.exception.Exception500;
 import net.chatfoodie.server.chat.ChatSessionInfo;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
@@ -57,11 +59,10 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
         try {
             messageDtoInterface = toMessageDto(payload);
             if (messageDtoInterface.notValidate()) {
-                log.error("올바른 형식의 메시지가 아닙니다.");
                 throw new RuntimeException();
             }
         } catch (Exception e) {
-            log.error("올바른 형식의 메시지가 아닙니다.");
+            session.sendMessage(userWebSocketService.createErrorMessage("올바른 형식의 메시지가 아닙니다."));
             session.close();
             return;
         }
@@ -70,12 +71,23 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
         try {
             foodieMessageDto = toFoodieMessageDto(messageDtoInterface, session);
         } catch (Exception e) {
-            log.error("잘못된 입력입니다.");
+            session.sendMessage(userWebSocketService.createErrorMessage("잘못된 입력입니다."));
             session.close();
             return;
         }
 
-        requestToFoodie(messageDtoInterface, foodieMessageDto, session);
+        try {
+            requestToFoodie(messageDtoInterface, foodieMessageDto, session);
+        } catch (Exception500 | Exception400 e) {
+            session.sendMessage(userWebSocketService.createErrorMessage(e.getMessage()));
+            session.close();
+        } catch (JsonProcessingException e) {
+            session.sendMessage(userWebSocketService.createErrorMessage("메시지 변환 중 오류가 발생했습니다."));
+            session.close();
+        } catch (Exception e) {
+            session.sendMessage(userWebSocketService.createErrorMessage("챗봇에게 요청 중 오류가 발생했습니다."));
+            session.close();
+        }
     }
 
     protected abstract ChatUserRequest.MessageDtoInterface toMessageDto(String payload) throws JsonProcessingException;
@@ -83,7 +95,7 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
 
     protected abstract ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session);
 
-    protected abstract void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session);
+    protected abstract void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) throws IOException;
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -28,6 +28,13 @@ public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
 
     @Override
     protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) {
-        userWebSocketService.requestToFoodiePublic(foodieMessageDto, session);
+        var messageDto = (ChatUserRequest.PublicMessageDto) messageDtoInterface;
+        String requestMessage;
+        try {
+            requestMessage = om.writeValueAsString(messageDto);
+        } catch (JsonProcessingException e) {
+            requestMessage = "유저 메시지를 JSON 화 중 오류 발생했습니다.";
+        }
+        userWebSocketService.requestToFoodiePublic(foodieMessageDto, session, requestMessage);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketPublicApiHandler.java
@@ -8,6 +8,8 @@ import net.chatfoodie.server.chat.service.UserWebSocketService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.io.IOException;
+
 @Component
 public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
 
@@ -27,14 +29,10 @@ public class UserWebSocketPublicApiHandler extends UserWebSocketBaseHandler {
     }
 
     @Override
-    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) {
+    protected void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) throws IOException {
         var messageDto = (ChatUserRequest.PublicMessageDto) messageDtoInterface;
         String requestMessage;
-        try {
-            requestMessage = om.writeValueAsString(messageDto);
-        } catch (JsonProcessingException e) {
-            requestMessage = "유저 메시지를 JSON 화 중 오류 발생했습니다.";
-        }
+        requestMessage = om.writeValueAsString(messageDto);
         userWebSocketService.requestToFoodiePublic(foodieMessageDto, session, requestMessage);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
@@ -1,0 +1,43 @@
+package net.chatfoodie.server.chat.publiclog;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_public_log_tb")
+public class ChatPublicLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20)
+    private String ip;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestMessage;
+
+    @Column(columnDefinition = "TEXT")
+    private String output;
+
+    @ColumnDefault(value = "now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ChatPublicLog(Long id, String ip, String requestMessage, String output, LocalDateTime createdAt) {
+        this.id = id;
+        this.ip = ip;
+        this.requestMessage = requestMessage;
+        this.output = output;
+        this.createdAt = createdAt;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "chat_public_log_tb")
+@Table(name = "chat_public_log_tb",
+        indexes = {
+            @Index(name = "chat_public_log_created_at_idx", columnList = "createdAt")
+        })
 public class ChatPublicLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/publiclog/ChatPublicLog.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "chat_public_log_tb",
         indexes = {
-            @Index(name = "chat_public_log_created_at_idx", columnList = "createdAt")
+            @Index(name = "chat_public_log_ip_created_at_idx", columnList = "ip, createdAt")
         })
 public class ChatPublicLog {
     @Id

--- a/server/src/main/java/net/chatfoodie/server/chat/publiclog/repository/ChatPublicLogRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/publiclog/repository/ChatPublicLogRepository.java
@@ -1,0 +1,10 @@
+package net.chatfoodie.server.chat.publiclog.repository;
+
+import net.chatfoodie.server.chat.publiclog.ChatPublicLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatPublicLogRepository extends JpaRepository<ChatPublicLog, Long> {
+
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/publiclog/repository/ChatPublicLogRepository.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/publiclog/repository/ChatPublicLogRepository.java
@@ -4,7 +4,11 @@ import net.chatfoodie.server.chat.publiclog.ChatPublicLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 @Repository
 public interface ChatPublicLogRepository extends JpaRepository<ChatPublicLog, Long> {
+
+    Long countByIpAndCreatedAtBetween(String ip, LocalDateTime start, LocalDateTime end);
 
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/Chatroom.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/Chatroom.java
@@ -15,7 +15,10 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "chatroom_tb")
+@Table(name = "chatroom_tb",
+        indexes = {
+                @Index(name = "chatroom_user_id_idx", columnList = "user_id")
+        })
 public class Chatroom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/message/Message.java
@@ -16,7 +16,10 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "message_tb")
+@Table(name = "message_tb",
+        indexes = {
+                @Index(name = "message_chatroom_id_idx", columnList = "chatroom_id")
+        })
 public class Message {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/EmailVerification.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/EmailVerification.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "email_verification_tb")
+@Table(name = "email_verification_tb",
+        indexes = {
+                @Index(name = "email_verification_email_idx", columnList = "email")
+        })
 public class EmailVerification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/server/src/main/java/net/chatfoodie/server/favor/Favor.java
+++ b/server/src/main/java/net/chatfoodie/server/favor/Favor.java
@@ -15,7 +15,10 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "favor_tb")
+@Table(name = "favor_tb",
+        indexes = {
+                @Index(name = "favor_user_id_idx", columnList = "user_id")
+        })
 public class Favor {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary

웹소켓에 있어서 계획 했던 부분을 전부 구현 완료 및 에러 핸들링까지 마쳤습니다.

## Description

- 비회원 요청의 IP와 메시지들을 저장하는 `chat_public_log_tb`를 만들었습니다.
- 비회원의 경우 자정 기준으로 하루 최대 20번의 요청을 가능하도록 하였습니다.
- 회원의 경우 선호도를 채팅을 추가하도록 하였습니다.
- `userWebSocketBaseHandler`에서 `Exception`을 `catch`하여 접속한 유저에게 에러 메시지를 전달하고 세션을 닫도록 하였습니다.
  ```json
    {
      "event": "error",
      "response": "일일 최대 횟수에 도달했습니다."
    }
  ```
- 내부 로직에서 `Exception500`이나 `Exception400`으로 메시지를 작성해 던지면 그걸 `BaseHandler`에서 `catch`하여 메시지 내용을 그대로 response에 담아 전달하게 됩니다.
- 최종적으로 메시지 전달을 완료하든 에러가 발생해 에러 메시지를 전달하든 서버 측에서 강제로 세션을 닫도록 구현하였습니다.
- 이를 통해 현재 연결된 세션 수를 세어 대기열을 만들어 줄 수도 있을 것입니다.( 추후 확장 기능 #81 )

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #67 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->