### PR TITLE
비회원용 채팅 기능 완성

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Header from "@/containers/home/header"
 import Footer from "@/containers/home/footer"
 import Navigator from "@/containers/home/navigator"
 import AuthProvider from "@/contexts/authContextProvider"
+import ChatroomProvider from "@/contexts/chatroomContextProvider"
 
 const notoSans = Noto_Sans_KR({
   weight: ["100", "300", "400", "500", "700", "900"],
@@ -23,14 +24,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko">
       <AuthProvider>
-        <body className={`${notoSans.className} flex pt-7 pb-7 box-border min-h-screen`}>
-          <Navigator />
-          <main className="flex grow flex-col">
-            <Header />
-            <section className="grow">{children}</section>
-            <Footer />
-          </main>
-        </body>
+        <ChatroomProvider>
+          <body className={`${notoSans.className} flex pt-7 pb-7 box-border min-h-screen`}>
+            <Navigator />
+            <main className="flex grow flex-col">
+              <Header />
+              <section className="grow">{children}</section>
+              <Footer />
+            </main>
+          </body>
+        </ChatroomProvider>
       </AuthProvider>
     </html>
   )

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -8,12 +8,35 @@ import { scrollDownChatBox } from "@/containers/chat/message-box-list"
 
 export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [streamingMessage, setStreamingMessage] = useState<string>("")
 
   const addMessage = (message: ChatMessage) => {
     setMessages((messagesState) => {
       const saveMessage = { ...message }
-      if (saveMessage.id === 0) saveMessage.id = messagesState.length + 1
+      if (saveMessage.id === 0) {
+        if (messagesState.length === 0) {
+          // 없으면 1부터 시작
+          saveMessage.id = 1
+        } else {
+          // 가장 마지막보다 1크게 부여
+          saveMessage.id = messagesState[messagesState.length - 1].id
+        }
+        saveMessage.id = messagesState.length + 1
+      }
       return [...messagesState, saveMessage]
+    })
+  }
+  const handleStreamMessage = (message: string) => {
+    setStreamingMessage((prevState) => {
+      if (message === "") {
+        const chatbotMessage: ChatMessage = {
+          id: 0,
+          content: prevState,
+          isFromChatbot: true,
+        }
+        addMessage(chatbotMessage)
+      }
+      return message
     })
   }
 
@@ -23,8 +46,8 @@ export default function ChatUi() {
 
   return (
     <div className="flex flex-col min-h-full">
-      <MessageBoxListContainer messages={messages} />
-      <MessageInputContainer messages={messages} addMessage={addMessage} />
+      <MessageBoxListContainer messages={messages} streamingMessage={streamingMessage} />
+      <MessageInputContainer messages={messages} addMessage={addMessage} handleStreamMessage={handleStreamMessage} />
     </div>
   )
 }

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -24,7 +24,7 @@ export default function ChatUi() {
   return (
     <div className="flex flex-col min-h-full">
       <MessageBoxListContainer messages={messages} />
-      <MessageInputContainer addMessage={addMessage} />
+      <MessageInputContainer messages={messages} addMessage={addMessage} />
     </div>
   )
 }

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -42,7 +42,7 @@ export default function ChatUi() {
 
   useEffect(() => {
     scrollDownChatBox()
-  }, [messages])
+  }, [streamingMessage])
 
   return (
     <div className="flex flex-col min-h-full">

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -8,6 +8,7 @@ import { scrollDownChatBox } from "@/containers/chat/message-box-list"
 
 export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [tempUserMessage, setTempUserMessage] = useState<string>("")
   const [streamingMessage, setStreamingMessage] = useState<string>("")
 
   const addMessage = (message: ChatMessage) => {
@@ -27,6 +28,17 @@ export default function ChatUi() {
     })
   }
   const handleStreamMessage = (message: string) => {
+    if (message === "") {
+      setTempUserMessage((prevState) => {
+        const userMessage: ChatMessage = {
+          id: 0,
+          content: prevState,
+          isFromChatbot: false,
+        }
+        addMessage(userMessage)
+        return ""
+      })
+    }
     setStreamingMessage((prevState) => {
       if (message === "") {
         const chatbotMessage: ChatMessage = {
@@ -46,8 +58,16 @@ export default function ChatUi() {
 
   return (
     <div className="flex flex-col min-h-full">
-      <MessageBoxListContainer messages={messages} streamingMessage={streamingMessage} />
-      <MessageInputContainer messages={messages} addMessage={addMessage} handleStreamMessage={handleStreamMessage} />
+      <MessageBoxListContainer
+        messages={messages}
+        tempUserMessage={tempUserMessage}
+        streamingMessage={streamingMessage}
+      />
+      <MessageInputContainer
+        messages={messages}
+        handleStreamMessage={handleStreamMessage}
+        setTempUserMessage={setTempUserMessage}
+      />
     </div>
   )
 }

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -70,7 +70,6 @@ export default function ChatUi() {
       <MessageInputContainer
         messages={messages}
         handleStreamMessage={handleStreamMessage}
-        tempUserMessage={tempUserMessage}
         setTempUserMessage={setTempUserMessage}
         prepareRegenerate={prepareRegenerate}
       />

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -27,8 +27,8 @@ export default function ChatUi() {
       return [...messagesState, saveMessage]
     })
   }
-  const handleStreamMessage = (message: string) => {
-    if (message === "") {
+  const handleStreamMessage = (message: string, regenerate: boolean) => {
+    if (!regenerate && message === "") {
       setTempUserMessage((prevState) => {
         const userMessage: ChatMessage = {
           id: 0,
@@ -52,6 +52,10 @@ export default function ChatUi() {
     })
   }
 
+  const prepareRegenerate = () => {
+    setMessages((prevState) => prevState.slice(0, -1))
+  }
+
   useEffect(() => {
     scrollDownChatBox()
   }, [streamingMessage])
@@ -66,7 +70,9 @@ export default function ChatUi() {
       <MessageInputContainer
         messages={messages}
         handleStreamMessage={handleStreamMessage}
+        tempUserMessage={tempUserMessage}
         setTempUserMessage={setTempUserMessage}
+        prepareRegenerate={prepareRegenerate}
       />
     </div>
   )

--- a/client/src/containers/chat/message-box-list-container.tsx
+++ b/client/src/containers/chat/message-box-list-container.tsx
@@ -3,21 +3,23 @@ import MessageBoxList from "@/containers/chat/message-box-list"
 
 export default function MessageBoxListContainer({
   messages,
+  tempUserMessage,
   streamingMessage,
 }: {
   messages: ChatMessage[]
+  tempUserMessage: string
   streamingMessage: string
 }) {
   return (
     <div className="grow flex justify-center items-center h-0">
-      {messages.length === 0 ? (
+      {messages.length === 0 && tempUserMessage === "" ? (
         <div className="grow flex justify-center items-center flex-col">
           <p>빈화면은 심심하니까</p>
           <br />
           <p>예시 채팅이라던지 튜토리얼 안내문</p>
         </div>
       ) : (
-        <MessageBoxList messages={messages} streamingMessage={streamingMessage} />
+        <MessageBoxList messages={messages} tempUserMessage={tempUserMessage} streamingMessage={streamingMessage} />
       )}
     </div>
   )

--- a/client/src/containers/chat/message-box-list-container.tsx
+++ b/client/src/containers/chat/message-box-list-container.tsx
@@ -1,7 +1,13 @@
 import { ChatMessage } from "@/types/chat"
 import MessageBoxList from "@/containers/chat/message-box-list"
 
-export default function MessageBoxListContainer({ messages }: { messages: ChatMessage[] }) {
+export default function MessageBoxListContainer({
+  messages,
+  streamingMessage,
+}: {
+  messages: ChatMessage[]
+  streamingMessage: string
+}) {
   return (
     <div className="grow flex justify-center items-center h-0">
       {messages.length === 0 ? (
@@ -11,7 +17,7 @@ export default function MessageBoxListContainer({ messages }: { messages: ChatMe
           <p>예시 채팅이라던지 튜토리얼 안내문</p>
         </div>
       ) : (
-        <MessageBoxList messages={messages} />
+        <MessageBoxList messages={messages} streamingMessage={streamingMessage} />
       )}
     </div>
   )

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -1,7 +1,23 @@
 import Image from "next/image"
+import { useEffect } from "react"
 import { ChatMessage } from "@/types/chat"
 
+export const scrollDownChatBox = () => {
+  const chatBox = document.querySelector<HTMLElement>("#chat-main")
+
+  if (chatBox !== null && chatBox.scrollHeight - (chatBox.scrollTop + chatBox.clientHeight) <= 80) {
+    chatBox.scrollTop = chatBox.scrollHeight
+  }
+}
+
 function MessageBox({ message }: { message: ChatMessage }) {
+  useEffect(() => {
+    const chatBox = document.querySelector<HTMLElement>("#chat-main")
+    if (chatBox !== null) {
+      chatBox.scrollTop = chatBox.scrollHeight
+    }
+  }, [])
+
   return (
     <div
       className={`${message.isFromChatbot ? "bg-gray-100 " : ""}pt-10 pb-14 flex justify-center items-center w-full`}
@@ -39,12 +55,4 @@ export default function MessageBoxList({
       ) : null}
     </div>
   )
-}
-
-export const scrollDownChatBox = () => {
-  const chatBox = document.querySelector<HTMLElement>("#chat-main")
-
-  if (chatBox !== null) {
-    chatBox.scrollTop = chatBox.scrollHeight
-  }
 }

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -26,7 +26,6 @@ export default function MessageBoxList({ messages }: { messages: ChatMessage[] }
   return (
     <div className="w-full overflow-y-scroll custom-scroll-bar-10px h-full" id="chat-main">
       {messages.map((message) => {
-        console.log(message)
         return <MessageBox message={message} key={message.id} />
       })}
     </div>

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -4,8 +4,7 @@ import { ChatMessage } from "@/types/chat"
 
 export const scrollDownChatBox = () => {
   const chatBox = document.querySelector<HTMLElement>("#chat-main")
-
-  if (chatBox !== null && chatBox.scrollHeight - (chatBox.scrollTop + chatBox.clientHeight) <= 80) {
+  if (chatBox !== null && chatBox.scrollHeight - (chatBox.scrollTop + chatBox.clientHeight) <= 24) {
     chatBox.scrollTop = chatBox.scrollHeight
   }
 }

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -40,9 +40,11 @@ function MessageBox({ message }: { message: ChatMessage }) {
 
 export default function MessageBoxList({
   messages,
+  tempUserMessage,
   streamingMessage,
 }: {
   messages: ChatMessage[]
+  tempUserMessage: string
   streamingMessage: string
 }) {
   return (
@@ -50,6 +52,9 @@ export default function MessageBoxList({
       {messages.map((message) => {
         return <MessageBox message={message} key={message.id} />
       })}
+      {tempUserMessage !== "" ? (
+        <MessageBox message={{ id: 0, content: tempUserMessage, isFromChatbot: false }} />
+      ) : null}
       {streamingMessage !== "" ? (
         <MessageBox message={{ id: 0, content: streamingMessage, isFromChatbot: true }} />
       ) : null}

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -22,12 +22,21 @@ function MessageBox({ message }: { message: ChatMessage }) {
   )
 }
 
-export default function MessageBoxList({ messages }: { messages: ChatMessage[] }) {
+export default function MessageBoxList({
+  messages,
+  streamingMessage,
+}: {
+  messages: ChatMessage[]
+  streamingMessage: string
+}) {
   return (
     <div className="w-full overflow-y-scroll custom-scroll-bar-10px h-full" id="chat-main">
       {messages.map((message) => {
         return <MessageBox message={message} key={message.id} />
       })}
+      {streamingMessage !== "" ? (
+        <MessageBox message={{ id: 0, content: streamingMessage, isFromChatbot: true }} />
+      ) : null}
     </div>
   )
 }

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -46,8 +46,11 @@ export default function MessageInputContainer({
     // const socket = io.connect(`${process.env.NEXT_PUBLIC_API_URL}/api/public-chat`)
     const socket = new WebSocket(`${process.env.NEXT_PUBLIC_WS_URL}/api/public-chat`)
 
+    let successConnect = false
+
     socket.addEventListener("open", () => {
       // 서버로 메시지 전송
+      successConnect = true
       socket.send(
         JSON.stringify({
           input: userInputValue,
@@ -61,29 +64,25 @@ export default function MessageInputContainer({
       const res = JSON.parse(event.data)
       switch (res.event) {
         case "text_stream": {
-          // const chatbotMessage: ChatMessage = {
-          //   id: 0,
-          //   content: res.response,
-          //   isFromChatbot: true,
-          // }
           handleStreamMessage(res.response)
           break
         }
         case "stream_end":
-          console.log("종료 신호 옴")
           handleStreamMessage("")
           socket.close()
           break
         case "error":
           alert(res.response)
+          socket.close()
           break
         default:
           alert("서버 통신 중 오류가 발생했습니다.")
+          socket.close()
       }
     })
 
-    socket.addEventListener("close", (event) => {
-      console.log("WebSocket이 닫혔습니다.", event)
+    socket.addEventListener("close", () => {
+      if (!successConnect) alert("채팅 서버에 연결할 수 없습니다!")
     })
   }
 

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -1,16 +1,15 @@
 import Image from "next/image"
 import { ChatMessage } from "@/types/chat"
 import { limitInputNumber, pressEnter } from "@/utils/utils"
-import { scrollDownChatBox } from "@/containers/chat/message-box-list"
 
 export default function MessageInputContainer({
   messages,
-  addMessage,
   handleStreamMessage,
+  setTempUserMessage,
 }: {
   messages: ChatMessage[]
-  addMessage: (message: ChatMessage) => void
   handleStreamMessage: (message: string) => void
+  setTempUserMessage: (message: string) => void
 }) {
   const resizeBox = (e: any) => {
     e.target.style.height = "24px"
@@ -43,62 +42,60 @@ export default function MessageInputContainer({
     return history
   }
 
-  const onSendClick = () => {
-    const userInputBox = document.getElementById("user-input-box") as HTMLTextAreaElement
+  function generateFoodieResponse(userInputValue: string) {
+    // const socket = io.connect(`${process.env.NEXT_PUBLIC_API_URL}/api/public-chat`)
+    const socket = new WebSocket(`${process.env.NEXT_PUBLIC_WS_URL}/api/public-chat`)
 
-    const userInputValue = userInputBox.value
-    if (userInputValue) {
-      const userMessage: ChatMessage = {
-        id: 0,
-        content: userInputBox.value,
-        isFromChatbot: false,
-      }
-      addMessage(userMessage)
-      scrollDownChatBox()
+    socket.addEventListener("open", () => {
+      // 서버로 메시지 전송
+      socket.send(
+        JSON.stringify({
+          input: userInputValue,
+          history: makeHistory(),
+          regenerate: false,
+        }),
+      )
+    })
 
-      // const socket = io.connect(`${process.env.NEXT_PUBLIC_API_URL}/api/public-chat`)
-      const socket = new WebSocket("ws://localhost:8080/api/public-chat")
-
-      socket.addEventListener("open", () => {
-        // 서버로 메시지 전송
-        socket.send(
-          JSON.stringify({
-            input: userInputValue,
-            history: makeHistory(),
-            regenerate: false,
-          }),
-        )
-      })
-      socket.addEventListener("message", (event) => {
-        const res = JSON.parse(event.data)
-        switch (res.event) {
-          case "text_stream": {
-            // const chatbotMessage: ChatMessage = {
-            //   id: 0,
-            //   content: res.response,
-            //   isFromChatbot: true,
-            // }
-            handleStreamMessage(res.response)
-            break
-          }
-          case "stream_end":
-            console.log("종료 신호 옴")
-            handleStreamMessage("")
-            socket.close()
-            break
-          case "error":
-            alert(res.response)
-            break
-          default:
-            alert("서버 통신 중 오류가 발생했습니다.")
+    socket.addEventListener("message", (event) => {
+      const res = JSON.parse(event.data)
+      switch (res.event) {
+        case "text_stream": {
+          // const chatbotMessage: ChatMessage = {
+          //   id: 0,
+          //   content: res.response,
+          //   isFromChatbot: true,
+          // }
+          handleStreamMessage(res.response)
+          break
         }
-      })
+        case "stream_end":
+          console.log("종료 신호 옴")
+          handleStreamMessage("")
+          socket.close()
+          break
+        case "error":
+          alert(res.response)
+          break
+        default:
+          alert("서버 통신 중 오류가 발생했습니다.")
+      }
+    })
 
-      socket.addEventListener("close", (event) => {
-        console.log("WebSocket이 닫혔습니다.", event)
-      })
+    socket.addEventListener("close", (event) => {
+      console.log("WebSocket이 닫혔습니다.", event)
+    })
+  }
 
-      userInputBox.value = ""
+  const onSendClick = () => {
+    const userInputBox = document.querySelector<HTMLTextAreaElement>("#user-input-box")
+
+    const userInputValue = userInputBox!.value
+    if (userInputValue) {
+      setTempUserMessage(userInputValue)
+      generateFoodieResponse(userInputValue)
+
+      userInputBox!.value = ""
     }
   }
 

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -1,23 +1,19 @@
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { ChatMessage } from "@/types/chat"
 import { limitInputNumber, pressEnter } from "@/utils/utils"
 
 export default function MessageInputContainer({
   messages,
   handleStreamMessage,
-  tempUserMessage,
   setTempUserMessage,
   prepareRegenerate,
 }: {
   messages: ChatMessage[]
   handleStreamMessage: (message: string, regenerate: boolean) => void
-  tempUserMessage: string
   setTempUserMessage: (message: string) => void
   prepareRegenerate: () => void
 }) {
-  const [displayRegenerate, setDisplayRegenerate] = useState(false)
-
   const [isGenerating, setIsGenerating] = useState(false)
 
   const resizeBox = () => {
@@ -90,11 +86,10 @@ export default function MessageInputContainer({
           alert("서버 통신 중 오류가 발생했습니다.")
       }
       socket.close()
-      if (regenerate) setDisplayRegenerate(true)
-      setIsGenerating(false)
     })
 
     socket.addEventListener("close", () => {
+      setIsGenerating(false)
       if (!successConnect) alert("채팅 서버에 연결할 수 없습니다!")
     })
   }
@@ -102,7 +97,6 @@ export default function MessageInputContainer({
   const onRegenerateClick = () => {
     if (isGenerating) return
     setIsGenerating(true)
-    setDisplayRegenerate(false)
     prepareRegenerate()
     generateFoodieResponse("", true)
   }
@@ -121,21 +115,13 @@ export default function MessageInputContainer({
     }
   }
 
-  useEffect(() => {
-    if (messages.length === 0) setDisplayRegenerate(false)
-  }, [messages.length])
-
-  useEffect(() => {
-    setDisplayRegenerate(tempUserMessage === "")
-  }, [tempUserMessage])
-
   return (
     <div className="flex justify-center">
       <div className="flex justify-center mt-3 mb-6 w-[60%] border-2 border-solid border-gray-400 rounded py-3 box-content relative">
         <button
           type="button"
           className={`w-[10rem] border bg-white border-gray-400 rounded flex justify-center items-center h-9 mb-4 absolute -top-14 opacity-70 hover:opacity-100 transition${
-            displayRegenerate ? "" : " invisible"
+            messages.length !== 0 && !isGenerating ? "" : " invisible"
           }`}
           onClick={onRegenerateClick}
         >

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -20,9 +20,13 @@ export default function MessageInputContainer({
 
   const [isGenerating, setIsGenerating] = useState(false)
 
-  const resizeBox = (e: any) => {
-    e.target.style.height = "24px"
-    e.target.style.height = `${Math.min(e.target.scrollHeight, 120)}px`
+  const resizeBox = () => {
+    const userInputBox = document.querySelector<HTMLTextAreaElement>("#user-input-box")
+
+    if (userInputBox !== null) {
+      userInputBox.style.height = "24px"
+      userInputBox.style.height = `${Math.min(userInputBox.scrollHeight, 120)}px`
+    }
   }
 
   const makeHistory = () => {
@@ -112,8 +116,8 @@ export default function MessageInputContainer({
       setTempUserMessage(userInputValue)
       setIsGenerating(true)
       generateFoodieResponse(userInputValue, false)
-
       userInputBox!.value = ""
+      resizeBox()
     }
   }
 
@@ -122,7 +126,7 @@ export default function MessageInputContainer({
   }, [messages.length])
 
   useEffect(() => {
-    if (tempUserMessage === "") setDisplayRegenerate(true)
+    setDisplayRegenerate(tempUserMessage === "")
   }, [tempUserMessage])
 
   return (
@@ -142,12 +146,11 @@ export default function MessageInputContainer({
           className="w-full focus:outline-none pl-5 mr-5 custom-scroll-bar-4px overflow-y scroll resize-none h-6"
           id="user-input-box"
           onChange={(e) => {
-            resizeBox(e)
             limitInputNumber(e, 500)
+            resizeBox()
           }}
           onKeyDown={(e) => {
             pressEnter(e, onSendClick)
-            resizeBox(e)
           }}
           placeholder="메시지를 입력해주세요"
         />

--- a/client/src/contexts/chatroomContextProvider.tsx
+++ b/client/src/contexts/chatroomContextProvider.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { createContext, ReactNode, useMemo, useState } from "react"
+
+export const ChatroomContext = createContext<any>({})
+
+export default function ChatroomProvider({ children }: { children: ReactNode }) {
+  const [chatroomId, setChatroomId] = useState(0)
+
+  const value = useMemo(
+    () => ({
+      chatroomId,
+      setChatroomId,
+    }),
+    [chatroomId],
+  )
+
+  return <ChatroomContext.Provider value={value}>{children}</ChatroomContext.Provider>
+}

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -47,5 +47,91 @@
         background-color: rgb(0,0,0,0.2);
         border-radius: 100px;
     }
+
+    .dot-elastic {
+        position: relative;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        background-color: theme('colors.main-theme');
+        color: theme('colors.main-theme');
+        animation: dot-elastic 1s infinite linear;
+    }
+    .dot-elastic::before, .dot-elastic::after {
+        content: "";
+        display: inline-block;
+        position: absolute;
+        top: 0;
+    }
+    .dot-elastic::before {
+        left: -12px;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        background-color: theme('colors.main-theme');
+        color: theme('colors.main-theme');
+        animation: dot-elastic-before 1s infinite linear;
+    }
+    .dot-elastic::after {
+        left: 12px;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        background-color: theme('colors.main-theme');
+        color: theme('colors.main-theme');
+        animation: dot-elastic-after 1s infinite linear;
+    }
+
+    @keyframes dot-elastic-before {
+        0% {
+            transform: scale(1, 1);
+        }
+        25% {
+            transform: scale(1, 1.5);
+        }
+        50% {
+            transform: scale(1, 0.67);
+        }
+        75% {
+            transform: scale(1, 1);
+        }
+        100% {
+            transform: scale(1, 1);
+        }
+    }
+    @keyframes dot-elastic {
+        0% {
+            transform: scale(1, 1);
+        }
+        25% {
+            transform: scale(1, 1);
+        }
+        50% {
+            transform: scale(1, 1.5);
+        }
+        75% {
+            transform: scale(1, 1);
+        }
+        100% {
+            transform: scale(1, 1);
+        }
+    }
+    @keyframes dot-elastic-after {
+        0% {
+            transform: scale(1, 1);
+        }
+        25% {
+            transform: scale(1, 1);
+        }
+        50% {
+            transform: scale(1, 0.67);
+        }
+        75% {
+            transform: scale(1, 1.5);
+        }
+        100% {
+            transform: scale(1, 1);
+        }
+    }
     
 }


### PR DESCRIPTION
## Summary

채팅되게 구현했습니다. 로딩은 인풋박스의 전송 버튼을 로딩 애니메이션으로 바꾸는 형태로 했습니다.

## Description

- 서버로 웹소켓으로 메시지를 보내고 돌아오는 답변을 실시간으로 ui에 뿌리게 만들었습니다.
- 대화내역이 쌓여 스크롤이 생기면 채팅이 생성되고 완성될때 스크롤이 자동으로 맨 밑으로 가도록 해놨습니다.
- 아직 응답이 완성되지 못한 경우(stream_end 이벤트 수신 직전까지) temp state에 사용자의 입력과 챗봇의 스트리밍 메시지가 들어갑니다. 그 후 stream_end 이벤트 수신 시 messages state로 옮겨 관리 됩니다.
- 답변 재생성의 경우 다음과 같은 상황에서 나타나도록 하였습니다
  - 재생성할 응답이 존재하는 경우
  - 서버에서 답변이 오고 있는 중이 아닌 경우
- 로딩중(답변을 생성하는 중)을 애니메이션으로 시각화 하였습니다.


이제 다음으로 회원용 채팅 하겠습니다.


## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #100 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->