### PR TITLE
회원용 채팅 구현

### DIFF
--- a/client/.env.local.example
+++ b/client/.env.local.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_WS_URL=ws://localhost:8080

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -5,5 +5,5 @@ module.exports = {
   images: {
     domains: ["localhost"], // 이미지를 호스팅하는 도메인을 여기에 추가
   },
-  nextConfig,
+  ...nextConfig,
 }

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -14,7 +14,6 @@ export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [tempUserMessage, setTempUserMessage] = useState<string>("")
   const [streamingMessage, setStreamingMessage] = useState<string>("")
-  const [refresh, setRefresh] = useState(false)
 
   const { userId } = useContext(AuthContext)
   const { chatroomId, setChatroomId } = useContext(ChatroomContext)
@@ -34,7 +33,7 @@ export default function ChatUi() {
     })
   }
 
-  const handleStreamMessage = async (message: string, regenerate: boolean) => {
+  const handleStreamMessage = async (message: string, regenerate: boolean, chatroomIdToSend: number) => {
     if (!regenerate && message === "") {
       setTempUserMessage((prevState) => {
         const userMessage: ChatMessage = {
@@ -49,20 +48,15 @@ export default function ChatUi() {
 
     let messagesToAdd: ChatMessage[] = []
     if (message === "" && userId !== 0) {
-      if (chatroomId !== 0) {
-        const headers = { Authorization: getJwtTokenFromStorage() }
-        const params = { size: 2 }
-        const res = await proxy.get(`/chatrooms/${chatroomId}/messages`, { headers, params })
-        const newMessages: ChatMessage[] = res.data.response.body.messages
-        if (messages.length === 0) {
-          messagesToAdd = newMessages
-        } else {
-          const skipIndex = newMessages.map((m) => m.id).indexOf(messages.at(-1)!.id)
-          messagesToAdd = skipIndex === -1 ? newMessages : newMessages.slice(skipIndex)
-        }
+      const headers = { Authorization: getJwtTokenFromStorage() }
+      const params = { size: 2 }
+      const res = await proxy.get(`/chatrooms/${chatroomIdToSend}/messages`, { headers, params })
+      const newMessages: ChatMessage[] = res.data.response.body.messages
+      if (messages.length === 0) {
+        messagesToAdd = newMessages
       } else {
-        console.log("여기냐?")
-        setRefresh((prev) => !prev)
+        const skipIndex = newMessages.map((m) => m.id).indexOf(messages.at(-1)!.id)
+        messagesToAdd = skipIndex === -1 ? newMessages : newMessages.slice(skipIndex)
       }
     }
 
@@ -105,7 +99,7 @@ export default function ChatUi() {
           alert(res.response.data.errorMessage)
         })
     }
-  }, [chatroomId, refresh])
+  }, [chatroomId])
 
   useEffect(() => {
     setMessages([])

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -1,16 +1,20 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import MessageInputContainer from "@/containers/chat/message-input-container"
 import MessageBoxListContainer from "@/containers/chat/message-box-list-container"
 import { ChatMessage } from "@/types/chat"
 import { scrollDownChatBox } from "@/containers/chat/message-box-list"
+import { ChatroomContext } from "@/contexts/chatroomContextProvider"
+import proxy from "@/utils/proxy"
+import { getJwtTokenFromStorage } from "@/utils/jwtDecoder"
 
 export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [tempUserMessage, setTempUserMessage] = useState<string>("")
   const [streamingMessage, setStreamingMessage] = useState<string>("")
 
+  const { chatroomId, setChatroomId } = useContext(ChatroomContext)
   const addMessage = (message: ChatMessage) => {
     setMessages((messagesState) => {
       const saveMessage = { ...message }
@@ -20,9 +24,8 @@ export default function ChatUi() {
           saveMessage.id = 1
         } else {
           // 가장 마지막보다 1크게 부여
-          saveMessage.id = messagesState[messagesState.length - 1].id
+          saveMessage.id = messagesState[messagesState.length - 1].id + 1
         }
-        saveMessage.id = messagesState.length + 1
       }
       return [...messagesState, saveMessage]
     })
@@ -60,8 +63,44 @@ export default function ChatUi() {
     scrollDownChatBox()
   }, [streamingMessage])
 
+  useEffect(() => {
+    const currentChatroomId: number = chatroomId
+
+    if (currentChatroomId === 0) {
+      setMessages([])
+    } else {
+      const headers = { Authorization: getJwtTokenFromStorage() }
+      const params = { size: 2 }
+      proxy
+        .get(`/chatrooms/${currentChatroomId}/messages`, { headers, params })
+        .then((res) => {
+          setMessages(res.data.response.body.messages)
+        })
+        .catch((res) => {
+          alert(res.response.data.errorMessage)
+        })
+    }
+  }, [chatroomId])
+
   return (
     <div className="flex flex-col min-h-full">
+      <label htmlFor="chatroomIdtemp" className="block w-80 h-16 mb-3">
+        <span className="block text-sm font-medium text-slate-700">임시 채팅방 선택창(진짜 있는 채팅방만 선택!!)</span>
+        <select
+          name="chatroomIdtemp"
+          className="mt-1 px-3 py-2 bg-white border shadow-sm border-slate-300 placeholder-slate-400 focus:outline-none focus:border-main-theme focus:ring-main-theme block w-full rounded-md sm:text-sm focus:ring-1"
+          onChange={(e) => {
+            setChatroomId(Number(e.currentTarget.value))
+          }}
+          value={chatroomId}
+        >
+          {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => (
+            <option value={num} key={num}>
+              {num}
+            </option>
+          ))}
+        </select>
+      </label>
       <MessageBoxListContainer
         messages={messages}
         tempUserMessage={tempUserMessage}

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -4,7 +4,7 @@ import { ChatMessage } from "@/types/chat"
 
 export const scrollDownChatBox = () => {
   const chatBox = document.querySelector<HTMLElement>("#chat-main")
-  if (chatBox !== null && chatBox.scrollHeight - (chatBox.scrollTop + chatBox.clientHeight) <= 24) {
+  if (chatBox !== null && chatBox.scrollHeight - (chatBox.scrollTop + chatBox.clientHeight) <= 30) {
     chatBox.scrollTop = chatBox.scrollHeight
   }
 }

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -117,7 +117,7 @@ export default function MessageInputContainer({
 
   return (
     <div className="flex justify-center">
-      <div className="flex justify-center mt-3 mb-6 w-[60%] border-2 border-solid border-gray-400 rounded py-3 box-content relative">
+      <div className="flex justify-center mt-3 mb-6 w-[60%] border-2 border-solid border-gray-400 rounded py-3 box-content relative focus-within:shadow-[0_0_4px_4px_rgba(0,0,0,0.1)]">
         <button
           type="button"
           className={`w-[10rem] border bg-white border-gray-400 rounded flex justify-center items-center h-9 mb-4 absolute -top-14 opacity-70 hover:opacity-100 transition${

--- a/server/src/main/java/net/chatfoodie/server/_core/security/JwtAuthenticationFilter.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package net.chatfoodie.server._core.security;
 
-import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.servlet.FilterChain;
@@ -50,14 +49,12 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
                     );
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("인증 객체 생성됨");
-        } catch (SignatureVerificationException e) {
-            log.error("토큰 검증 실패");
         } catch (TokenExpiredException e) {
             log.error("토큰 만료");
+        } catch (Exception e) {
+            log.error("토큰 검증 실패");
         } finally {
             chain.doFilter(request, response);
         }
     }
-
-
 }

--- a/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
 
         // 10. 인증, 권한 필터 설정
         http.authorizeHttpRequests(authorize ->
-                        authorize.requestMatchers("/api/chatrooms/**", "/api/users/**", "api/chat").hasRole("USER")
+                        authorize.requestMatchers("/api/chatrooms/**", "/api/users/**").hasRole("USER")
                                 .requestMatchers("/api/email-verifications/**").hasAnyRole("PENDING", "USER")
                                 .anyRequest().permitAll()
         );

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -1,11 +1,15 @@
 package net.chatfoodie.server.chat.handler;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
 import net.chatfoodie.server.chat.service.UserWebSocketService;
+import net.chatfoodie.server.user.Role;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -14,6 +18,29 @@ import java.io.IOException;
 @Slf4j
 @Component
 public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        String token;
+        try {
+            token = userWebSocketService.extractTokenFromSession(session);
+        } catch (Exception e) {
+            session.close();
+            return;
+        }
+        try {
+            DecodedJWT decodedJWT = JwtProvider.verify(token);
+            Role role = decodedJWT.getClaim("role").as(Role.class);
+            if (role != Role.ROLE_USER) throw new RuntimeException();
+        } catch (TokenExpiredException e) {
+            log.error("토큰 만료");
+            session.close();
+        } catch (Exception e) {
+            log.error("토큰 검증 실패");
+            session.close();
+        }
+        super.afterConnectionEstablished(session);
+    }
 
     public UserWebSocketApiHandler(UserWebSocketService userWebSocketService, ObjectMapper om) {
         super(userWebSocketService, om);

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketApiHandler.java
@@ -51,7 +51,7 @@ public class UserWebSocketApiHandler extends UserWebSocketBaseHandler {
     }
 
     @Override
-    protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) {
+    protected ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) throws IOException {
         Long userId = userWebSocketService.getUserId(session);
 
         return userWebSocketService.makeFoodieRequestDto(

--- a/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/handler/UserWebSocketBaseHandler.java
@@ -92,7 +92,7 @@ public abstract class UserWebSocketBaseHandler extends TextWebSocketHandler {
     protected abstract ChatUserRequest.MessageDtoInterface toMessageDto(String payload) throws JsonProcessingException;
 
 
-    protected abstract ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session);
+    protected abstract ChatFoodieRequest.MessageDto toFoodieMessageDto(ChatUserRequest.MessageDtoInterface messageDto, WebSocketSession session) throws IOException;
 
     protected abstract void requestToFoodie(ChatUserRequest.MessageDtoInterface messageDtoInterface, ChatFoodieRequest.MessageDto foodieMessageDto, WebSocketSession session) throws IOException;
 

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -120,15 +120,10 @@ public class UserWebSocketService {
         });
     }
 
-    public Long getUserId(WebSocketSession session) {
-        Authentication authentication = (Authentication) session.getPrincipal();
-
-        if (authentication == null) {
-            throw new RuntimeException();
-        }
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-
-        return customUserDetails.getId();
+    public Long getUserId(WebSocketSession session) throws IOException {
+        String token = extractTokenFromSession(session);
+        DecodedJWT decodedJWT = JwtProvider.verify(token);
+        return decodedJWT.getClaim("id").asLong();
     }
 
     @Transactional

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -1,5 +1,7 @@
 package net.chatfoodie.server.chat.service;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +12,7 @@ import net.chatfoodie.server._core.errors.exception.Exception403;
 import net.chatfoodie.server._core.errors.exception.Exception404;
 import net.chatfoodie.server._core.errors.exception.Exception500;
 import net.chatfoodie.server._core.security.CustomUserDetails;
+import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server._core.utils.MyFunction;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
 import net.chatfoodie.server.chat.dto.ChatUserRequest;
@@ -23,6 +26,7 @@ import net.chatfoodie.server.chatroom.repository.ChatroomRepository;
 import net.chatfoodie.server.favor.Favor;
 import net.chatfoodie.server.favor.repository.FavorRepository;
 import net.chatfoodie.server.food.Food;
+import net.chatfoodie.server.user.Role;
 import net.chatfoodie.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -287,5 +291,23 @@ public class UserWebSocketService {
             log.error("ErrorMessage를 만드는 중 오류 발생했습니다.:" + message);
             return new TextMessage("{\"event\":\"error\",\"response\":\"서버 에러입니다.\"}");
         }
+    }
+
+    public String extractTokenFromSession(WebSocketSession session) throws IOException {
+        String queryString = Objects.requireNonNull(session.getUri()).getQuery();
+
+        if (queryString == null) {
+            log.info(session + "클라이언트의 토큰이 존재 하지 않음");
+            throw new RuntimeException();
+        }
+        String tokenParam = "token=";
+        int tokenParamIndex = queryString.indexOf(tokenParam);
+        if (tokenParamIndex == -1) {
+            throw new RuntimeException();
+        }
+        int tokenValueStartIndex = tokenParamIndex + tokenParam.length();
+        int tokenValueSplitIndex = queryString.indexOf('&', tokenValueStartIndex);
+        int tokenValueEndIndex = tokenValueSplitIndex == -1 ? queryString.length() : tokenValueSplitIndex;
+        return queryString.substring(tokenValueStartIndex, tokenValueEndIndex);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/controller/ChatroomController.java
@@ -22,8 +22,8 @@ public class ChatroomController {
 
     @PostMapping("/chatrooms")
     public ResponseEntity<?> create(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        chatroomService.create(userDetails.getId());
-        ApiUtils.Response<?> response = ApiUtils.success();
+        ChatroomResponse.CreateChatroomDto createChatroomDto = chatroomService.create(userDetails.getId());
+        ApiUtils.Response<?> response = ApiUtils.success(createChatroomDto);
         return ResponseEntity.ok().body(response);
     }
 

--- a/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/dto/ChatroomResponse.java
@@ -49,4 +49,12 @@ public class ChatroomResponse {
 
         }
     }
+
+    public record CreateChatroomDto(
+            Long chatroomId
+    ) {
+        public CreateChatroomDto(Chatroom chatroom) {
+            this(chatroom.getId());
+        }
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
+++ b/server/src/main/java/net/chatfoodie/server/chatroom/service/ChatroomService.java
@@ -35,7 +35,7 @@ public class ChatroomService {
     final private UserRepository userRepository;
     final private MessageRepository messageRepository;
 
-    public void create(Long userId) {
+    public ChatroomResponse.CreateChatroomDto create(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new Exception404("회원이 존재하지 않습니다"));
 
         String title = Utils.convertDateTimeToString(LocalDateTime.now()) + " 음식 추천";
@@ -46,7 +46,9 @@ public class ChatroomService {
                                 .build();
 
         try {
-            chatroomRepository.save(chatroom);
+            Chatroom createdChatroom = chatroomRepository.save(chatroom);
+            return new ChatroomResponse.CreateChatroomDto(createdChatroom);
+
         } catch (Exception e) {
             throw new Exception500("채팅방 생성 중 오류가 발생하였습니다.");
         }


### PR DESCRIPTION
## Summary

회원용 웹소켓 기반 스트리밍 채팅을 구현하였습니다. 헤더에 jwt 넣는 방식이 불가능해 query parameter에 넣었습니다.

## Description

- query parameter로 전달하는 JWT를 해석하도록 서버를 수정하였습니다.
- 로그인 상태(Cotext 사용)를 바탕으로 전송 버튼에 각각 다른 동작을 하도록 설정해놨습니다.
  - 코드가 더러울 수 있습니다 😢
- 채팅방 테스트를 위해 간단하게 임시 채팅방 선택 select를 만들어 작업하였습니다. Navigator의 채팅방 UI가 완성되면 지우면 됩니다.
- 회원이 채팅방을 선택하지 않으면 전송 버튼 클릭시 새로운 채팅방을 만들고 그곳에서 즉시 채팅이 시작됩니다
- messages state는 항상 서버의 db를 바탕으로 랜더링하도록하였습니다. tempUser메시지와 streaming메시지는 사라지며 동시에 서버에 요청을 해 그것으로 교체합니다.

## 추가

- 채팅 input 상자에 focus 이벤트로 그림자를 만들었습니다.
- 새로 채팅방 만들었을때 깜빡이는 문제가 있는데 해결법을 모르겠습니다..

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #100 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->