### PR TITLE
답변 생성 완료 후의 깜빡임 제거

### DIFF
--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -11,8 +11,6 @@ import { AuthContext } from "@/contexts/authContextProvider"
 
 export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
-  const [tempUserMessage, setTempUserMessage] = useState<string>("")
-  const [streamingMessage, setStreamingMessage] = useState<string>("")
   const messageNextKey = useRef<number>(1)
 
   const getMessagesLength = 20
@@ -30,56 +28,54 @@ export default function ChatUi() {
       return newMessage
     })
   }
-  const addMessage = (message: ChatMessage) => {
+  const addMessage = (message: string, isFromChatbot: boolean) => {
     setMessages((messagesState) => {
-      return [...messagesState, ...toChatMessageFormat([message])]
+      const chatMessage: ChatMessage = {
+        key: 0,
+        content: message,
+        isFromChatbot,
+      }
+      return [...messagesState, ...toChatMessageFormat([chatMessage])]
     })
   }
 
-  const handleStreamMessage = async (message: string, regenerate: boolean, chatroomIdToSend: number) => {
+  const handleStreamMessage = async (message: string, chatroomIdToSend: number) => {
     const finishStreaming = message === ""
-    if (!regenerate && finishStreaming) {
-      setTempUserMessage((prevState) => {
-        if (userId === 0) {
-          const userMessage: ChatMessage = {
-            key: 0,
-            content: prevState,
-            isFromChatbot: false,
-          }
-          addMessage(userMessage)
-        }
-        return ""
-      })
-    }
 
-    let messagesToAdd: ChatMessage[] = []
-    if (message === "" && userId !== 0) {
+    if (!finishStreaming) {
+      setMessages((prevState) => {
+        const lastMessage = prevState[prevState.length - 1]
+        if (lastMessage && lastMessage.isFromChatbot) {
+          lastMessage.content = message
+          return [...prevState.slice(0, -1), lastMessage]
+        }
+        const chatMessage: ChatMessage = {
+          key: 0,
+          content: message,
+          isFromChatbot: true,
+        }
+        return [...prevState, ...toChatMessageFormat([chatMessage])]
+      })
+    } else if (userId !== 0) {
       const headers = { Authorization: getJwtTokenFromStorage() }
       const params = { size: 2 }
       const res = await proxy.get(`/chatrooms/${chatroomIdToSend}/messages`, { headers, params })
-      const newMessages: ChatMessage[] = res.data.response.body.messages
-      if (messages.length === 0) {
-        messagesToAdd = newMessages
-      } else {
-        const skipIndex = newMessages.map((m) => m.id).indexOf(messages.at(-1)!.id)
-        messagesToAdd = skipIndex === -1 ? newMessages : newMessages.slice(skipIndex)
-      }
-    }
 
-    setStreamingMessage((prevState) => {
-      if (message === "") {
-        const chatbotMessage: ChatMessage = {
-          key: 0,
-          content: prevState,
-          isFromChatbot: true,
-        }
-        if (userId === 0) addMessage(chatbotMessage)
-        else {
-          setMessages((prev) => [...prev, ...toChatMessageFormat(messagesToAdd)])
-        }
-      }
-      return message
-    })
+      const newMessages: ChatMessage[] = res.data.response.body.messages
+
+      setMessages((prevState) => {
+        const keyOfNeedToSync = prevState.filter((m) => m.id === undefined).map((m) => m.key)
+
+        const messagesToAdd = newMessages
+          .filter((m) => !prevState.map((prev) => prev.id).includes(m.id))
+          .map((m, index) => {
+            const ret = m
+            ret.key = keyOfNeedToSync[index]
+            return ret
+          })
+        return [...prevState.filter((m) => m.id), ...messagesToAdd]
+      })
+    }
   }
 
   const prepareRegenerate = () => {
@@ -98,7 +94,10 @@ export default function ChatUi() {
         .then((res) => {
           const patchedMessages = res.data.response.body.messages
           if (_cursor.key === undefined) {
-            setMessages(toChatMessageFormat(patchedMessages))
+            setMessages((prev) => {
+              const remain = prev.filter((chatMessage) => chatMessage.id === undefined)
+              return [...toChatMessageFormat(patchedMessages), ...remain]
+            })
           } else {
             setMessages((prev) => [...toChatMessageFormat(patchedMessages), ...prev])
           }
@@ -152,15 +151,13 @@ export default function ChatUi() {
       ) : null}
       <MessageBoxListContainer
         messages={messages}
-        tempUserMessage={tempUserMessage}
-        streamingMessage={streamingMessage}
         // cursor={cursor}
         // getMessages={getMessages}
       />
       <MessageInputContainer
         messages={messages}
         handleStreamMessage={handleStreamMessage}
-        setTempUserMessage={setTempUserMessage}
+        addUserMessage={(message: string) => addMessage(message, false)}
         prepareRegenerate={prepareRegenerate}
       />
     </div>

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useCallback, useContext, useEffect, useState } from "react"
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
 import MessageInputContainer from "@/containers/chat/message-input-container"
 import MessageBoxListContainer from "@/containers/chat/message-box-list-container"
 import { ChatMessage, Cursor } from "@/types/chat"
@@ -13,6 +13,7 @@ export default function ChatUi() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [tempUserMessage, setTempUserMessage] = useState<string>("")
   const [streamingMessage, setStreamingMessage] = useState<string>("")
+  const messageNextKey = useRef<number>(1)
 
   const getMessagesLength = 20
 
@@ -23,15 +24,9 @@ export default function ChatUi() {
   const addMessage = (message: ChatMessage) => {
     setMessages((messagesState) => {
       const saveMessage = { ...message }
-      if (saveMessage.id === 0) {
-        if (messagesState.length === 0) {
-          // 없으면 1부터 시작
-          saveMessage.id = 1
-        } else {
-          // 가장 마지막보다 1크게 부여
-          saveMessage.id = messagesState[messagesState.length - 1].id + 1
-        }
-      }
+
+      saveMessage.key = messageNextKey.current
+      messageNextKey.current += 1
       return [...messagesState, saveMessage]
     })
   }
@@ -40,7 +35,7 @@ export default function ChatUi() {
     if (!regenerate && message === "") {
       setTempUserMessage((prevState) => {
         const userMessage: ChatMessage = {
-          id: 0,
+          key: 0,
           content: prevState,
           isFromChatbot: false,
         }
@@ -58,7 +53,7 @@ export default function ChatUi() {
       if (messages.length === 0) {
         messagesToAdd = newMessages
       } else {
-        const skipIndex = newMessages.map((m) => m.id).indexOf(messages.at(-1)!.id)
+        const skipIndex = newMessages.map((m) => m.key).indexOf(messages.at(-1)!.key)
         messagesToAdd = skipIndex === -1 ? newMessages : newMessages.slice(skipIndex)
       }
     }
@@ -66,7 +61,7 @@ export default function ChatUi() {
     setStreamingMessage((prevState) => {
       if (message === "") {
         const chatbotMessage: ChatMessage = {
-          id: 0,
+          key: 0,
           content: prevState,
           isFromChatbot: true,
         }

--- a/client/src/containers/chat/message-box-list-container.tsx
+++ b/client/src/containers/chat/message-box-list-container.tsx
@@ -2,19 +2,15 @@ import { ChatMessage } from "@/types/chat"
 import MessageBoxList from "@/containers/chat/message-box-list"
 
 export default function MessageBoxListContainer({
-  messages,
-  tempUserMessage,
-  streamingMessage, // cursor,getMessages,
+  messages, // cursor,getMessages,
 }: {
   messages: ChatMessage[]
-  tempUserMessage: string
-  streamingMessage: string
   // cursor: Cursor
   // getMessages: (_cursor: Cursor) => void
 }) {
   return (
     <div className="grow flex justify-center items-center h-0">
-      {messages.length === 0 && tempUserMessage === "" ? (
+      {messages.length === 0 ? (
         <div className="grow flex justify-center items-center flex-col">
           <p>빈화면은 심심하니까</p>
           <br />
@@ -23,8 +19,6 @@ export default function MessageBoxListContainer({
       ) : (
         <MessageBoxList
           messages={messages}
-          tempUserMessage={tempUserMessage}
-          streamingMessage={streamingMessage}
           // cursor={cursor}
           // getMessages={getMessages}
         />

--- a/client/src/containers/chat/message-box-list-container.tsx
+++ b/client/src/containers/chat/message-box-list-container.tsx
@@ -1,4 +1,4 @@
-import { ChatMessage, Cursor } from "@/types/chat"
+import { ChatMessage } from "@/types/chat"
 import MessageBoxList from "@/containers/chat/message-box-list"
 
 export default function MessageBoxListContainer({

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -31,13 +31,9 @@ function MessageBox({ message, chatBox }: { message: ChatMessage; chatBox: Forwa
 }
 
 export default function MessageBoxList({
-  messages,
-  tempUserMessage,
-  streamingMessage, // cursor, getMessages,
+  messages, // cursor, getMessages,
 }: {
   messages: ChatMessage[]
-  tempUserMessage: string
-  streamingMessage: string
   // cursor: Cursor
   // getMessages: (_cursor: Cursor) => void
 }) {
@@ -57,7 +53,7 @@ export default function MessageBoxList({
 
   useEffect(() => {
     scrollTraceDownChatBox()
-  }, [streamingMessage])
+  }, [messages])
 
   // useEffect(() => {
   //   const instance = chatBox.current!
@@ -84,12 +80,6 @@ export default function MessageBoxList({
       {messages.map((message) => {
         return <MessageBox message={message} key={message.key} chatBox={chatBox} />
       })}
-      {tempUserMessage !== "" ? (
-        <MessageBox message={{ key: 0, content: tempUserMessage, isFromChatbot: false }} chatBox={chatBox} />
-      ) : null}
-      {streamingMessage !== "" ? (
-        <MessageBox message={{ key: 0, content: streamingMessage, isFromChatbot: true }} chatBox={chatBox} />
-      ) : null}
     </div>
   )
 }

--- a/client/src/containers/chat/message-box-list.tsx
+++ b/client/src/containers/chat/message-box-list.tsx
@@ -82,13 +82,13 @@ export default function MessageBoxList({
   return (
     <div className="w-full overflow-y-scroll custom-scroll-bar-10px h-full" id="chat-main" ref={chatBox}>
       {messages.map((message) => {
-        return <MessageBox message={message} key={message.id} chatBox={chatBox} />
+        return <MessageBox message={message} key={message.key} chatBox={chatBox} />
       })}
       {tempUserMessage !== "" ? (
-        <MessageBox message={{ id: 0, content: tempUserMessage, isFromChatbot: false }} chatBox={chatBox} />
+        <MessageBox message={{ key: 0, content: tempUserMessage, isFromChatbot: false }} chatBox={chatBox} />
       ) : null}
       {streamingMessage !== "" ? (
-        <MessageBox message={{ id: 0, content: streamingMessage, isFromChatbot: true }} chatBox={chatBox} />
+        <MessageBox message={{ key: 0, content: streamingMessage, isFromChatbot: true }} chatBox={chatBox} />
       ) : null}
     </div>
   )

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -11,12 +11,12 @@ import proxy from "@/utils/proxy"
 export default function MessageInputContainer({
   messages,
   handleStreamMessage,
-  setTempUserMessage,
+  addUserMessage,
   prepareRegenerate,
 }: {
   messages: ChatMessage[]
-  handleStreamMessage: (message: string, regenerate: boolean, chatroomIdToSend: number) => void
-  setTempUserMessage: (message: string) => void
+  handleStreamMessage: (message: string, chatroomIdToSend: number) => void
+  addUserMessage: (message: string) => void
   prepareRegenerate: () => void
 }) {
   const [isGenerating, setIsGenerating] = useState(false)
@@ -105,11 +105,11 @@ export default function MessageInputContainer({
       const res = JSON.parse(event.data)
       switch (res.event) {
         case "text_stream": {
-          handleStreamMessage(res.response, regenerate, chatroomIdToSend)
+          handleStreamMessage(res.response, chatroomIdToSend)
           return
         }
         case "stream_end":
-          handleStreamMessage("", regenerate, chatroomIdToSend)
+          handleStreamMessage("", chatroomIdToSend)
           break
         case "error":
           alert(res.response)
@@ -139,7 +139,7 @@ export default function MessageInputContainer({
 
     const userInputValue = userInputBox!.value
     if (userInputValue) {
-      setTempUserMessage(userInputValue)
+      addUserMessage(userInputValue)
       setIsGenerating(true)
       generateFoodieResponse(userInputValue, false).then(() => {})
       userInputBox!.value = ""

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -1,5 +1,6 @@
 export interface ChatMessage {
-  id: number
+  key: number
+  id?: number
   content: string
   isFromChatbot: boolean
 }


### PR DESCRIPTION
## Summary

깜빡임을 제거하기 위해 chatMessage type의 구조를 개선하고 messages state하나로 모든 메세지를 관리하여 div 박스가 삭제 후 재생성이 아닌 내부 값만 변경하도록 하였습니다.

## Description

원래는 회원인 경우 id값을 key로 하여 map으로 생성하였으나 이 과정에서 리액트가 임시 저장(아직 스트리밍 중일때) 메시지 박스와 완료 후 메시지 박스를 동일한 걸로 판단하지 못하고 삭제후 재생성을 하며 깜빡임이 있었습니다 😱 

이를 해결하기 위해 동일 state로 messages 안에서 전부 관리하도록 tempUserMessage와 streamingMessage state를 제거하였습니다.

또한 회원의 경우 서버와의 sync를 맞추기 위해 별도로 undefined가 가능한 id를 생성하였습니다.(기존의 id를 리액트 컴포넌트 배열 생성을 위한 key로 변경하고 메시지 pk를 저장할 id? 를 만들었습니다.)

스트리밍 완료 신호가 오면 로그인된 회원의 경우 id가 undefined인 메시지들의 key값을 따로 저장한뒤 key값을 유지하며 서버에서 들고온 메시지들로 갈아끼웁니다. 이과정에서 key는 변하지 않아 리액트가 내부에 수정이 필요한 부분만 일부분 수정할 수 있기 때문에 깜빡임이 사라집니다.