### PR TITLE
유저 프로필 확인하기 창 및 이메일 변경 시퀀스 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -22,6 +22,7 @@
     "prettier" // eslint-config-prettier prettier와 중복된 eslint 규칙 제거
   ],
   "rules": {
+    "no-restricted-globals": ["off", "confirm"],
     "react/require-default-props": "off",
     "no-alert": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -17,7 +17,7 @@ export default function Account() {
   const { userId, isLoad, userRole } = useContext(AuthContext)
   const [loginModalOpened, setLoginModalOpened] = useState(false)
   const [joinModalOpened, setJoinModalOpened] = useState(false)
-  const [emailVerificationModalOpend, setEmailVerificationModalOpend] = useState(false)
+  const [emailVerificationModalOpened, setEmailVerificationModalOpened] = useState(false)
   const [profileModalOpened, setProfileModalOpened] = useState(false)
   const [dropDownOpened, setDropDownOpened] = useState(false)
   const [preferenceModalOpened, setPreferenceModalOpened] = useState(false)
@@ -35,12 +35,14 @@ export default function Account() {
     }
   }, [userId])
   useEffect(() => {
-    if (userRole === "ROLE_PENDING") {
-      setEmailVerificationModalOpend(true)
-    } else if (userRole === "ROLE_USER") {
-      setEmailVerificationModalOpend(false)
+    if (isLoad) {
+      if (userId !== 0 && userRole === "ROLE_PENDING") {
+        setEmailVerificationModalOpened(true)
+      } else if (userId !== 0 && userRole === "ROLE_USER") {
+        setEmailVerificationModalOpened(false)
+      }
     }
-  }, [userRole])
+  }, [isLoad, userId, userRole])
 
   return (
     <div className="flex flex-wrap justify-end items-center h-min">
@@ -66,15 +68,15 @@ export default function Account() {
               {profileModalOpened ? (
                 <ProfileModal
                   onClickClose={() => setProfileModalOpened(false)}
-                  onClickEditEmail={() => setEmailVerificationModalOpend(true)}
+                  onClickEditEmail={() => setEmailVerificationModalOpened(true)}
                   onClickEditProfile={() => setEditProfileModalOpened(true)}
                 />
               ) : null}
               {editProfileModalOpened ? (
                 <EditProfileModal onClickClose={() => setEditProfileModalOpened(false)} />
               ) : null}
-              {emailVerificationModalOpend ? (
-                <EmailVerificationModal onClickClose={() => setEmailVerificationModalOpend(false)} />
+              {emailVerificationModalOpened ? (
+                <EmailVerificationModal onClickClose={() => setEmailVerificationModalOpened(false)} />
               ) : null}
               {preferenceModalOpened ? <PreferenceModal onClickClose={() => setPreferenceModalOpened(false)} /> : null}
 

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -10,6 +10,7 @@ import ProfileModal from "@/containers/account/profileModal"
 import DropDown from "@/containers/account/dropDown"
 import proxy from "@/utils/proxy"
 import { getJwtTokenFromStorage } from "@/utils/jwtDecoder"
+import EditProfileModal from "@/containers/account/editProfileModal"
 import PreferenceModal from "./preferenceModal"
 
 export default function Account() {
@@ -20,6 +21,7 @@ export default function Account() {
   const [profileModalOpened, setProfileModalOpened] = useState(false)
   const [dropDownOpened, setDropDownOpened] = useState(false)
   const [preferenceModalOpened, setPreferenceModalOpened] = useState(false)
+  const [editProfileModalOpened, setEditProfileModalOpened] = useState(false)
   const [userName, setUserName] = useState("")
 
   useEffect(() => {
@@ -65,12 +67,16 @@ export default function Account() {
                 <ProfileModal
                   onClickClose={() => setProfileModalOpened(false)}
                   onClickEditEmail={() => setEmailVerificationModalOpend(true)}
+                  onClickEditProfile={() => setEditProfileModalOpened(true)}
                 />
               ) : null}
-              {preferenceModalOpened ? <PreferenceModal onClickClose={() => setPreferenceModalOpened(false)} /> : null}
+              {editProfileModalOpened ? (
+                <EditProfileModal onClickClose={() => setEditProfileModalOpened(false)} />
+              ) : null}
               {emailVerificationModalOpend ? (
                 <EmailVerificationModal onClickClose={() => setEmailVerificationModalOpend(false)} />
               ) : null}
+              {preferenceModalOpened ? <PreferenceModal onClickClose={() => setPreferenceModalOpened(false)} /> : null}
 
               <DropDown
                 isOpened={dropDownOpened}

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -61,9 +61,14 @@ export default function Account() {
                 <Image className="shrink-0" src="/svg/dots.svg" alt="dots" width={24} height={24} />
               </button>
 
-              {profileModalOpened ? <ProfileModal onClickClose={() => setProfileModalOpened(false)} /> : null}
+              {profileModalOpened ? (
+                <ProfileModal
+                  onClickClose={() => setProfileModalOpened(false)}
+                  onClickEditEmail={() => setEmailVerificationModalOpend(true)}
+                />
+              ) : null}
               {preferenceModalOpened ? <PreferenceModal onClickClose={() => setPreferenceModalOpened(false)} /> : null}
-              {emailVerificationModalOpend && userRole === "ROLE_PENDING" ? (
+              {emailVerificationModalOpend ? (
                 <EmailVerificationModal onClickClose={() => setEmailVerificationModalOpend(false)} />
               ) : null}
 

--- a/client/src/containers/account/editProfileModal.tsx
+++ b/client/src/containers/account/editProfileModal.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import Modal from "@/components/modal"
+
+export default function EditProfileModal({ onClickClose }: { onClickClose(): void }) {
+  return (
+    <Modal onClickClose={onClickClose} description="">
+      <div className="p-5 h-0 grow">
+        <form className="overflow-y-scroll custom-scroll-bar-10px max-h-full -mr-[10px]" onSubmit={() => {}}>
+          <div className="flex flex-col items-center">
+            <button
+              className="bg-orange-400 hover:bg-main-theme text-white font-semibold py-2 px-4 rounded w-80 h-12"
+              type="submit"
+            >
+              정보 수정
+            </button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  )
+}

--- a/client/src/containers/account/joinModal.tsx
+++ b/client/src/containers/account/joinModal.tsx
@@ -229,7 +229,7 @@ export default function JoinModal({ onClickClose }: { onClickClose(): void }) {
   return (
     <Modal onClickClose={onClickClose}>
       <div className="p-5 h-0 grow">
-        <form className="overflow-y-scroll custom-scroll-bar-10px max-h-full" onSubmit={handleSubmit}>
+        <form className="overflow-y-scroll custom-scroll-bar-10px max-h-full -mr-[10px]" onSubmit={handleSubmit}>
           <div className="flex flex-col items-center">
             <TextField
               label="아이디"

--- a/client/src/containers/account/loginModal.tsx
+++ b/client/src/containers/account/loginModal.tsx
@@ -54,7 +54,7 @@ export default function LoginModal({ onClickClose }: { onClickClose(): void }) {
               placeholder="비밀번호를 입력하세요"
               onChange={(e) => limitInputNumber(e, 64)}
             />
-            <div className="flex justify-center m">
+            <div className="flex justify-center">
               <button
                 className="bg-orange-400 hover:bg-main-theme text-white font-semibold py-2 px-4 rounded w-80 h-12"
                 type="submit"

--- a/client/src/containers/account/profileModal.tsx
+++ b/client/src/containers/account/profileModal.tsx
@@ -19,9 +19,11 @@ function ProfileItem({ label, value }: { label: string; value: string }) {
 export default function ProfileModal({
   onClickClose,
   onClickEditEmail,
+  onClickEditProfile,
 }: {
   onClickClose(): void
   onClickEditEmail(): void
+  onClickEditProfile(): void
 }) {
   const [profile, setProfile] = useState({
     loginId: "",
@@ -78,6 +80,7 @@ export default function ProfileModal({
             type="button"
             className="bg-main-theme text-white rounded p-2"
             onClick={() => {
+              onClickEditProfile()
               onClickClose()
             }}
           >

--- a/client/src/containers/account/profileModal.tsx
+++ b/client/src/containers/account/profileModal.tsx
@@ -1,9 +1,51 @@
 import React, { useState } from "react"
 import Modal from "@/components/modal"
 import PreferenceModal from "@/containers/account/preferenceModal"
+import proxy from "@/utils/proxy"
+import { getJwtId, getJwtTokenFromStorage } from "@/utils/jwtDecoder"
+
+function ProfileItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="w-full min-h-[45px] h-auto flex items-center">
+      <div className="text-right pr-4 basis-1/4 font-bold">
+        <p>{label}</p>
+      </div>
+      <div className="basis-3/4 pl-4 flex flex-wrap break-keep">
+        <p>{value}</p>
+      </div>
+    </div>
+  )
+}
 
 export default function ProfileModal({ onClickClose }: { onClickClose(): void }) {
   const [preferenceModalOpened, setPreferenceModalOpened] = useState(false)
+
+  const [profile, setProfile] = useState({
+    loginId: "",
+    name: "",
+    email: "",
+    gender: "",
+    birth: "",
+    favors: "",
+  })
+
+  const headers = {
+    Authorization: getJwtTokenFromStorage(),
+  }
+  proxy.get(`/users/${getJwtId()}`, { headers }).then((res) => {
+    const { response } = res.data
+
+    const favorsString = response.favors.map((favor: { id: number; foodName: string }) => favor.foodName).join(", ")
+
+    setProfile({
+      loginId: response.loginId,
+      name: response.name,
+      email: response.email,
+      gender: response.gender ? "여성" : "남성",
+      birth: response.birth,
+      favors: favorsString || "없음",
+    })
+  })
 
   return (
     <>
@@ -16,24 +58,28 @@ export default function ProfileModal({ onClickClose }: { onClickClose(): void })
           />
         </div>
       ) : null}
-      <Modal onClickClose={onClickClose} description="회원정보">
-        <div className="p-4 relative">
-          {/* 회원 정보 표시 */}
-          {/* ... */}
-
-          {/* 개인정보 수정 버튼 */}
-          <button type="button" className="bg-main-theme text-white rounded p-2">
-            개인정보 수정
-          </button>
-
-          {/* 선호도 저장 버튼 */}
-          <button
-            type="button"
-            className="bg-main-theme text-white rounded p-2"
-            onClick={() => setPreferenceModalOpened(true)}
-          >
-            선호도 저장
-          </button>
+      <Modal onClickClose={onClickClose}>
+        <div className="p-4 relative h-full flex flex-col">
+          <div className="grow">
+            <ProfileItem label="아이디" value={profile.loginId} />
+            <ProfileItem label="이름" value={profile.name} />
+            <ProfileItem label="이메일" value={profile.email} />
+            <ProfileItem label="성별" value={profile.gender} />
+            <ProfileItem label="생년월일" value={profile.birth} />
+            <ProfileItem label="선호 음식" value={profile.favors} />
+          </div>
+          <div className="flex justify-end">
+            <button type="button" className="bg-main-theme text-white rounded p-2 mr-5">
+              개인정보 수정
+            </button>
+            <button
+              type="button"
+              className="bg-main-theme text-white rounded p-2"
+              onClick={() => setPreferenceModalOpened(true)}
+            >
+              선호 음식 변경
+            </button>
+          </div>
         </div>
       </Modal>
     </>

--- a/client/src/containers/account/profileModal.tsx
+++ b/client/src/containers/account/profileModal.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import Modal from "@/components/modal"
-import PreferenceModal from "@/containers/account/preferenceModal"
 import proxy from "@/utils/proxy"
 import { getJwtId, getJwtTokenFromStorage } from "@/utils/jwtDecoder"
 
@@ -17,9 +16,13 @@ function ProfileItem({ label, value }: { label: string; value: string }) {
   )
 }
 
-export default function ProfileModal({ onClickClose }: { onClickClose(): void }) {
-  const [preferenceModalOpened, setPreferenceModalOpened] = useState(false)
-
+export default function ProfileModal({
+  onClickClose,
+  onClickEditEmail,
+}: {
+  onClickClose(): void
+  onClickEditEmail(): void
+}) {
   const [profile, setProfile] = useState({
     loginId: "",
     name: "",
@@ -29,59 +32,50 @@ export default function ProfileModal({ onClickClose }: { onClickClose(): void })
     favors: "",
   })
 
-  const headers = {
-    Authorization: getJwtTokenFromStorage(),
-  }
-  proxy.get(`/users/${getJwtId()}`, { headers }).then((res) => {
-    const { response } = res.data
+  useEffect(() => {
+    const headers = {
+      Authorization: getJwtTokenFromStorage(),
+    }
+    proxy.get(`/users/${getJwtId()}`, { headers }).then((res) => {
+      const { response } = res.data
 
-    const favorsString = response.favors.map((favor: { id: number; foodName: string }) => favor.foodName).join(", ")
+      const favorsString = response.favors.map((favor: { id: number; foodName: string }) => favor.foodName).join(", ")
 
-    setProfile({
-      loginId: response.loginId,
-      name: response.name,
-      email: response.email,
-      gender: response.gender ? "여성" : "남성",
-      birth: response.birth,
-      favors: favorsString || "없음",
+      setProfile({
+        loginId: response.loginId,
+        name: response.name,
+        email: response.email,
+        gender: response.gender ? "여성" : "남성",
+        birth: response.birth,
+        favors: favorsString || "없음",
+      })
     })
-  })
+  }, [])
 
   return (
-    <>
-      {preferenceModalOpened ? (
-        <div className="fixed inset-0 flex items-center justify-center z-40">
-          <PreferenceModal
-            onClickClose={() => {
-              setPreferenceModalOpened(false)
-            }}
-          />
+    <Modal onClickClose={onClickClose} description="">
+      <div className="p-4 relative h-full flex flex-col mt-6">
+        <div className="grow">
+          <ProfileItem label="아이디" value={profile.loginId} />
+          <ProfileItem label="이름" value={profile.name} />
+          <ProfileItem label="이메일" value={profile.email} />
+          <ProfileItem label="성별" value={profile.gender} />
+          <ProfileItem label="생년월일" value={profile.birth} />
+          <ProfileItem label="선호 음식" value={profile.favors} />
         </div>
-      ) : null}
-      <Modal onClickClose={onClickClose}>
-        <div className="p-4 relative h-full flex flex-col">
-          <div className="grow">
-            <ProfileItem label="아이디" value={profile.loginId} />
-            <ProfileItem label="이름" value={profile.name} />
-            <ProfileItem label="이메일" value={profile.email} />
-            <ProfileItem label="성별" value={profile.gender} />
-            <ProfileItem label="생년월일" value={profile.birth} />
-            <ProfileItem label="선호 음식" value={profile.favors} />
-          </div>
-          <div className="flex justify-end">
-            <button type="button" className="bg-main-theme text-white rounded p-2 mr-5">
-              개인정보 수정
-            </button>
-            <button
-              type="button"
-              className="bg-main-theme text-white rounded p-2"
-              onClick={() => setPreferenceModalOpened(true)}
-            >
-              선호 음식 변경
-            </button>
-          </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="bg-main-theme text-white rounded p-2 mr-5"
+            onClick={() => onClickEditEmail()}
+          >
+            이메일 변경
+          </button>
+          <button type="button" className="bg-main-theme text-white rounded p-2">
+            개인정보 수정
+          </button>
         </div>
-      </Modal>
-    </>
+      </div>
+    </Modal>
   )
 }

--- a/client/src/containers/account/profileModal.tsx
+++ b/client/src/containers/account/profileModal.tsx
@@ -67,11 +67,20 @@ export default function ProfileModal({
           <button
             type="button"
             className="bg-main-theme text-white rounded p-2 mr-5"
-            onClick={() => onClickEditEmail()}
+            onClick={() => {
+              onClickEditEmail()
+              onClickClose()
+            }}
           >
             이메일 변경
           </button>
-          <button type="button" className="bg-main-theme text-white rounded p-2">
+          <button
+            type="button"
+            className="bg-main-theme text-white rounded p-2"
+            onClick={() => {
+              onClickClose()
+            }}
+          >
             개인정보 수정
           </button>
         </div>

--- a/client/src/containers/home/navigatorBox.tsx
+++ b/client/src/containers/home/navigatorBox.tsx
@@ -9,7 +9,7 @@ import ChatroomBox from "@/containers/home/chatroomBox"
 import { ChatRoom } from "@/types/chatroom"
 
 export default function NavigatorBox() {
-  const { userId, isLoad } = useContext(AuthContext)
+  const { userId, isLoad, userRole } = useContext(AuthContext)
   const { chatroomId, setChatroomId, update } = useContext(ChatroomContext)
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([])
 
@@ -51,12 +51,12 @@ export default function NavigatorBox() {
   }
 
   useEffect(() => {
-    if (userId !== 0) fetchChatRooms().then(() => {})
+    if (userId !== 0 && userRole !== "ROLE_PENDING") fetchChatRooms().then(() => {})
     else setChatRooms([])
   }, [chatroomId, userId])
 
   useEffect(() => {
-    if (userId !== 0) fetchChatRooms().then(() => {})
+    if (userId !== 0 && userRole !== "ROLE_PENDING") fetchChatRooms().then(() => {})
   }, [update, userId])
 
   return isLoad && userId !== 0 ? (

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -63,8 +63,8 @@ public class EmailVerificationService {
     }
 
     private void sendEmail(String email, String code) {
-        String subject = "chatfoodie 회원가입 인증번호입니다.";
-        String text = "회원가입을 위한 인증번호는 " + code + "입니다. </br>";
+        String subject = "chatfoodie 이메일 인증번호입니다.";
+        String text = "이메일 인증을 위한 인증번호는 " + code + "입니다. </br>";
 
         try {
             MimeMessage mimeMessage = javaMailSender.createMimeMessage();


### PR DESCRIPTION
## Summary

개인정보 확인을 할 수 있도록 창을 만들었습니다. 내부적으로 이메일 변경 및 개인정보 변경 버튼이 있습니다.

이메일 변경은 잘 되도록 해 놓았고 개인정보 변경 창만 내부에 코드를 작성하면 모든 UI가 끝이 날 것 같습니다.

## Description

- 프로필 모달을 만들며 버튼으로 이메일 변경 및 개인정보 변경을 놔두었습니다.
- 이미 인증된 유저가 이메일 변경 창에 들어갔을 때 추가적인 로직(이메일 변경 시도 시 재확인 창/ 창 나가도 로그아웃 안하도록 로직 추가)을 추가하였습니다.
- 개인정보 변경 버튼에 바인딩되는 `editProfileModal.tsx`을 만들어놨습니다. 추후 여기 파일을 작업해주시길 바랍니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #114 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->