### PR TITLE
드롭다운 사라지는 로직 변경

### DIFF
--- a/client/src/containers/account/dropDown.tsx
+++ b/client/src/containers/account/dropDown.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image"
-import { Dispatch, SetStateAction, useContext, useEffect } from "react"
+import { Dispatch, SetStateAction, useContext, useEffect, useRef } from "react"
 import { AuthContext } from "@/contexts/authContextProvider"
 import { deleteJwt } from "@/utils/jwtDecoder"
 
@@ -15,13 +15,16 @@ export default function DropDown({
   setProfileModalOpened: Dispatch<SetStateAction<boolean>>
 }) {
   const { needUpdate } = useContext(AuthContext)
+  const dropDownRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    const handleClick = () => {
-      if (isOpened) setIsOpened(false)
+    const handleClickOutside = (event: any) => {
+      if (dropDownRef.current && !dropDownRef.current.contains(event.target)) {
+        setIsOpened(false)
+      }
     }
-    document.addEventListener("mousedown", handleClick)
+    document.addEventListener("click", handleClickOutside)
     return () => {
-      document.removeEventListener("mousedown", handleClick)
+      document.removeEventListener("click", handleClickOutside)
     }
   }, [isOpened, setIsOpened])
   return (
@@ -29,6 +32,7 @@ export default function DropDown({
       className={`absolute top-0 right-0 mr-9 mt-24 w-[180px] z-20 py-2 rounded bg-gray-200 transition-all duration-300 ${
         isOpened ? "opacity-100 visible" : "opacity-0 invisible -translate-y-[4%]"
       }`}
+      ref={dropDownRef}
     >
       <div className="flex flex-col items-center">
         <button


### PR DESCRIPTION
## Summary

<!-- 간단하게 요약 -->
드롭다운 박스 밖을 클릭 시, 드롭다운을 끄게 하는 로직을 변경하였습니다.

## Description

<!-- 상세 내용 작성 -->
이유: 기존 로직은 드롭다운이 켜져있는 채로 프로필을 클릭하면 닫혔다 다시 열리는 현상이 발생하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->