### PR TITLE
navigator 열고 닫는 버튼 , 채팅방 hover효과 추가

### DIFF
--- a/client/public/svg/drawer.svg
+++ b/client/public/svg/drawer.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="M180-120q-24 0-42-18t-18-42v-600q0-24 18-42t42-18h600q24 0 42 18t18 42v600q0 24-18 42t-42 18H180Zm300-60h300v-600H480v600Z"/></svg>

--- a/client/src/containers/home/chatroomBox.tsx
+++ b/client/src/containers/home/chatroomBox.tsx
@@ -54,7 +54,10 @@ export default function ChatroomBox({
   if (!isLoad) return null
   if (userId !== 0)
     return (
-      <div className="flex items-center border-t-gray-300 border-t text-sm font-bold text-left" ref={containerRef}>
+      <div
+        className="flex items-center hover:bg-gray-100 border-t-gray-300 border-t text-sm font-bold text-left"
+        ref={containerRef}
+      >
         <Image src="/svg/message.svg" alt="message" height="12" width="12" className="ml-3.5 mr-3.5" />
         {editing ? (
           <input

--- a/client/src/containers/home/createChatRoomButton.tsx
+++ b/client/src/containers/home/createChatRoomButton.tsx
@@ -25,7 +25,7 @@ export default function CreateChatRoomButton() {
   return (
     <button
       type="button"
-      className="h-full w-full flex items-center"
+      className="h-full w-[80%] flex items-center"
       onClick={() => {
         if (userId !== 0) createNewChatroom().then()
         else window.location.href = "/"

--- a/client/src/containers/home/drawer.tsx
+++ b/client/src/containers/home/drawer.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import Image from "next/image"
+
+export default function Drawer({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  return (
+    <div className={`drawer ${isOpen ? "open" : ""}`}>
+      <div className="drawer-content">
+        <button type="button" className="drawer-close-button" onClick={onClose}>
+          <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" className="m-3" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/client/src/containers/home/drawer.tsx
+++ b/client/src/containers/home/drawer.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import Image from "next/image"
 
-export default function Drawer({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+export default function Drawer({ onClick }: { onClick: () => void }) {
   return (
-    <div className={`drawer ${isOpen ? "open" : ""}`}>
+    <div>
       <div className="drawer-content">
-        <button type="button" className="drawer-close-button" onClick={onClose}>
+        <button type="button" className="drawer-close-button" onClick={onClick}>
           <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" className="m-3" />
         </button>
       </div>

--- a/client/src/containers/home/navigator.tsx
+++ b/client/src/containers/home/navigator.tsx
@@ -12,7 +12,7 @@ export default function Navigator() {
   const [isNavigatorOpen, setIsNavigatorOpen] = useState(true)
 
   const toggleNavigator = () => {
-    setIsNavigatorOpen(!isNavigatorOpen)
+    setIsNavigatorOpen((prev) => !prev)
   }
 
   return isNavigatorOpen ? (
@@ -23,7 +23,7 @@ export default function Navigator() {
             <CreateChatRoomButton />
           </div>
           <div className="ml-4 mb-8 border-solid border border-gray-300 rounded-md h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
-            <Drawer isOpen={isNavigatorOpen} onClose={toggleNavigator} />
+            <Drawer onClick={toggleNavigator} />
           </div>
         </div>
         <div className="grow flex">
@@ -38,7 +38,7 @@ export default function Navigator() {
   ) : (
     <nav className="left-2 top-[30px] absolute">
       <div className="mb-8 border-solid border border-gray-300 rounded-md h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
-        <Drawer isOpen={isNavigatorOpen} onClose={toggleNavigator} />
+        <Drawer onClick={toggleNavigator} />
       </div>
     </nav>
   )

--- a/client/src/containers/home/navigator.tsx
+++ b/client/src/containers/home/navigator.tsx
@@ -1,16 +1,30 @@
-import React from "react"
+"use client"
+
+import React, { useState } from "react"
 
 import NavigatorBox from "@/containers/home/navigatorBox"
 import NavigatorToolBox from "@/containers/home/navigatorToollBox"
 import CreateChatRoomButton from "@/containers/home/createChatRoomButton"
 import DeleteAllChatroomButton from "@/containers/home/deleteAllChatroomButton"
+import Drawer from "@/containers/home/drawer"
 
 export default function Navigator() {
-  return (
+  const [isNavigatorOpen, setIsNavigatorOpen] = useState(true)
+
+  const toggleNavigator = () => {
+    setIsNavigatorOpen(!isNavigatorOpen)
+  }
+
+  return isNavigatorOpen ? (
     <nav className="flex flex-col min-w-[18rem] p-2.5 border-r-gray-200 border-r border-solid">
       <div className="h-full flex flex-col">
-        <div className="mb-8 border-solid border border-gray-300 rounded-md h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
-          <CreateChatRoomButton />
+        <div className="flex flex-row">
+          <div className="mb-8 border-solid border border-gray-300 rounded-md w-[80%] h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
+            <CreateChatRoomButton />
+          </div>
+          <div className="ml-4 mb-8 border-solid border border-gray-300 rounded-md h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
+            <Drawer isOpen={isNavigatorOpen} onClose={toggleNavigator} />
+          </div>
         </div>
         <div className="grow flex">
           <NavigatorBox />
@@ -19,6 +33,12 @@ export default function Navigator() {
           <DeleteAllChatroomButton />
           <NavigatorToolBox />
         </div>
+      </div>
+    </nav>
+  ) : (
+    <nav className="left-2 top-[30px] absolute">
+      <div className="mb-8 border-solid border border-gray-300 rounded-md h-11 flex items-center hover:bg-gray-100 hover:border-gray-200 transition">
+        <Drawer isOpen={isNavigatorOpen} onClose={toggleNavigator} />
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary

<!-- 간단하게 요약 -->
navigator 열고 닫는 버튼 , 채팅방 hover효과 추가
## Description

<!-- 상세 내용 작성 -->
네비게이터 채팅방생성 버튼 옆에 열고 닫는 버튼을 추가하였고 닫힌 상태에서는 여는 버튼만 좌측 상단에 보이게 하였습니다. 그리고 채팅방 목록에 hover효과를 추가하였습니다.
## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
close #127
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->