### PR TITLE
네비게이터 내부 요소들에게 미디어 쿼리 적용

### DIFF
--- a/client/src/components/navfooterTool.tsx
+++ b/client/src/components/navfooterTool.tsx
@@ -5,9 +5,9 @@ import React from "react"
 
 export default function NavFooterTool({ iconSrc, text, func }: { iconSrc: string; text: string; func: () => void }) {
   return (
-    <button type="button" className="flex mt-7 ml-2.5 items-center" onClick={func}>
+    <button type="button" className="flex mt-7 max-md:mt-5 ml-2.5 items-center" onClick={func}>
       <Image src={iconSrc} alt="" height="16" width="16" style={{ height: "16px" }} />
-      <p className="ml-2 text-sm">{text}</p>
+      <p className="ml-2 text-sm max-md:text-xs">{text}</p>
     </button>
   )
 }

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -187,13 +187,20 @@ export default function MessageInputContainer({
       <div className="flex justify-center items-center mt-3 mb-6 max-md:mb-2 w-[50%] max-lg:w-[70%] max-md:w-[90%] border-2 border-solid border-gray-400 rounded py-3 max-md:py-2 box-content relative focus-within:shadow-[0_0_4px_4px_rgba(0,0,0,0.1)]">
         <button
           type="button"
-          className={`w-[10rem] border bg-white border-gray-400 rounded flex justify-center items-center h-9 mb-4 absolute -top-14 opacity-70 hover:opacity-100 transition${
+          className={`px-8 border bg-white border-gray-400 rounded flex justify-center items-center py-1.5 mb-4 absolute -top-14 opacity-70 hover:opacity-100 transition${
             messages.length !== 0 && !isGenerating ? "" : " invisible"
           }`}
           onClick={onRegenerateClick}
         >
-          <Image src="/svg/refresh.svg" alt="" width="16" height="16" style={{ height: "16px" }} />
-          <p className="ml-2 text-sm">답변 재생성</p>
+          <Image
+            src="/svg/refresh.svg"
+            alt=""
+            width="16"
+            height="16"
+            style={{ height: "16px" }}
+            className="max-md:h-3.5 max-md:w-3.5"
+          />
+          <p className="ml-2 text-sm max-md:text-xs">답변 재생성</p>
         </button>
         <textarea
           className="w-full focus:outline-none pl-5 mr-5 custom-scroll-bar-4px overflow-y scroll resize-none h-6 max-md:text-sm max-md:h-5"

--- a/client/src/containers/home/chatroomBox.tsx
+++ b/client/src/containers/home/chatroomBox.tsx
@@ -57,7 +57,7 @@ export default function ChatroomBox({
   if (userId !== 0)
     return (
       <div
-        className="flex items-center hover:bg-gray-100 border-t-gray-300 border-t text-sm font-bold text-left"
+        className="flex items-center hover:bg-gray-100 border-t-gray-300 border-t text-sm max-md:text-xs font-bold text-left"
         ref={containerRef}
       >
         <Image src="/svg/message.svg" alt="message" height="12" width="12" className="ml-3.5 mr-3.5" />

--- a/client/src/containers/home/createChatRoomButton.tsx
+++ b/client/src/containers/home/createChatRoomButton.tsx
@@ -33,7 +33,7 @@ export default function CreateChatRoomButton({ onClickInnerButton }: { onClickIn
       }}
     >
       <Image src="/svg/add.svg" alt="add" height="20" width="20" className="ml-4" />
-      <p className="ml-2 text-sm font-bold">새로운 대화</p>
+      <p className="ml-2 text-sm font-bold max-md:text-xs">새로운 대화</p>
     </button>
   )
 }

--- a/client/src/containers/home/navigator.tsx
+++ b/client/src/containers/home/navigator.tsx
@@ -53,25 +53,21 @@ export default function Navigator() {
     <>
       <nav
         ref={navbarRef}
-        className={`absolute h-full z-10 flex flex-col min-w-[288px] py-9 px-2.5 border-r-gray-200 border-r border-solid transition-all ease-in-out duration-300 bg-white ${
+        className={`absolute h-full z-10 flex flex-col min-w-[288px] py-9 max-md:pb-5 px-2.5 border-r-gray-200 border-r border-solid transition-all ease-in-out duration-300 bg-white ${
           isNavigatorOpen ? "translate-x-0" : "-translate-x-full -mr-[288px]"
         }
       `}
       >
         <div className="h-full flex flex-col">
-          <div className="mb-8 h-11 flex flex-row items-center justify-center gap-2">
+          <div className="mb-8 max-md:mb-5 h-11 max-md:h-9 flex flex-row items-center justify-center gap-2">
             <CreateChatRoomButton onClickInnerButton={onClickInnerButton} />
-            <div>
-              <div className="drawer-content">
-                <button
-                  type="button"
-                  className="drawer-close-button border border-gray-300 rounded h-11 w-11 hover:bg-gray-100 transition flex items-center justify-center"
-                  onClick={() => setIsNavigatorOpen(false)}
-                >
-                  <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" />
-                </button>
-              </div>
-            </div>
+            <button
+              type="button"
+              className="drawer-close-button border border-gray-300 rounded h-full w-11 max-md:w-9 hover:bg-gray-100 transition flex items-center justify-center"
+              onClick={() => setIsNavigatorOpen(false)}
+            >
+              <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" />
+            </button>
           </div>
           <div className="grow flex">
             <NavigatorBox onClickInnerButton={onClickInnerButton} />
@@ -83,17 +79,13 @@ export default function Navigator() {
         </div>
       </nav>
       <div className="left-4 top-5 absolute" ref={navOpenButton}>
-        <div>
-          <div className="drawer-content">
-            <button
-              type="button"
-              className="drawer-close-button border border-gray-300 rounded h-11 w-11 max-md:h-7 max-md:w-7 hover:bg-gray-100 transition flex items-center justify-center"
-              onClick={() => setIsNavigatorOpen(true)}
-            >
-              <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" />
-            </button>
-          </div>
-        </div>
+        <button
+          type="button"
+          className="drawer-close-button border border-gray-300 rounded h-11 w-11 max-md:h-7 max-md:w-7 hover:bg-gray-100 transition flex items-center justify-center"
+          onClick={() => setIsNavigatorOpen(true)}
+        >
+          <Image src="/svg/drawer.svg" alt="drawer" height="20" width="20" />
+        </button>
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

네비게이터의 글자들 괜찮다고 생각했는데 작게 하는게 보기 더 편한 것 같아 바꿨습니다.

## Description

네비게이터의 하단 footer들의 마진을 줄여 채팅방 목록이 더 잘 보이도록 하였습니다.

글씨를 전부 xs로 변경하였고 새로운 대화 버튼의 크기와 주변 마진 또한 줄였습니다.

추가로 재생성 버튼을 까먹고 있었어서 이부분도 작게 처리하였습니다.