### PR TITLE
음식 선호도 최초 저장, 아이디 찾기, 비밀 번호 초기화 로직 구현

### DIFF
--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -141,7 +141,10 @@ export default function Account() {
               />
             ) : null}
             {findUserPasswordModalOpened ? (
-              <FindUserPasswordModal onClickClose={() => setFindUserPasswordModalOpened(false)} />
+              <FindUserPasswordModal
+                setLoginModalOpened={setLoginModalOpened}
+                onClickClose={() => setFindUserPasswordModalOpened(false)}
+              />
             ) : null}
           </>
         )

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -31,9 +31,12 @@ export default function Account() {
       }
       proxy.get(`/users/${userId}`, { headers }).then((res) => {
         setUserName(res.data.response.name)
+        if (userRole === "ROLE_USER" && res.data.response.favors.length === 0) {
+          setPreferenceModalOpened(true)
+        }
       })
     }
-  }, [userId])
+  }, [userId, userRole])
   useEffect(() => {
     if (isLoad) {
       if (userId !== 0 && userRole === "ROLE_PENDING") {

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -133,7 +133,13 @@ export default function Account() {
               />
             ) : null}
             {joinModalOpened ? <JoinModal onClickClose={() => setJoinModalOpened(false)} /> : null}
-            {findUserIdModalOpened ? <FindUserIdModal onClickClose={() => setFindUserIdModalOpened(false)} /> : null}
+            {findUserIdModalOpened ? (
+              <FindUserIdModal
+                setFindUserPasswordModalOpened={setFindUserPasswordModalOpened}
+                setLoginModalOpened={setLoginModalOpened}
+                onClickClose={() => setFindUserIdModalOpened(false)}
+              />
+            ) : null}
             {findUserPasswordModalOpened ? (
               <FindUserPasswordModal onClickClose={() => setFindUserPasswordModalOpened(false)} />
             ) : null}

--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -12,6 +12,8 @@ import proxy from "@/utils/proxy"
 import { getJwtTokenFromStorage } from "@/utils/jwtDecoder"
 import EditProfileModal from "@/containers/account/editProfileModal"
 import PreferenceModal from "./preferenceModal"
+import FindUserIdModal from "./findUserIdModal"
+import FindUserPasswordModal from "./findUserPasswordModal"
 
 export default function Account() {
   const { userId, isLoad, userRole } = useContext(AuthContext)
@@ -23,6 +25,8 @@ export default function Account() {
   const [preferenceModalOpened, setPreferenceModalOpened] = useState(false)
   const [editProfileModalOpened, setEditProfileModalOpened] = useState(false)
   const [userName, setUserName] = useState("")
+  const [findUserIdModalOpened, setFindUserIdModalOpened] = useState(false)
+  const [findUserPasswordModalOpened, setFindUserPasswordModalOpened] = useState(false)
 
   useEffect(() => {
     if (userId !== 0) {
@@ -118,9 +122,21 @@ export default function Account() {
                   setLoginModalOpened(false)
                   setJoinModalOpened(true)
                 }}
+                onClickFindId={() => {
+                  setLoginModalOpened(false)
+                  setFindUserIdModalOpened(true)
+                }}
+                onClickFindPassword={() => {
+                  setLoginModalOpened(false)
+                  setFindUserPasswordModalOpened(true)
+                }}
               />
             ) : null}
             {joinModalOpened ? <JoinModal onClickClose={() => setJoinModalOpened(false)} /> : null}
+            {findUserIdModalOpened ? <FindUserIdModal onClickClose={() => setFindUserIdModalOpened(false)} /> : null}
+            {findUserPasswordModalOpened ? (
+              <FindUserPasswordModal onClickClose={() => setFindUserPasswordModalOpened(false)} />
+            ) : null}
           </>
         )
       })()}

--- a/client/src/containers/account/findUserIdModal.tsx
+++ b/client/src/containers/account/findUserIdModal.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import React, { useState } from "react"
+import Modal from "@/components/modal"
+import proxy from "@/utils/proxy"
+import TextField from "@/components/textField"
+import { limitInputNumber } from "@/utils/utils"
+
+export default function FindUserIdModal({ onClickClose }: { onClickClose(): void }) {
+  const [formData, setFormData] = useState({
+    email: "",
+  })
+  const [errors, setErrors] = useState({
+    email: "",
+  })
+  const [message, setMessage] = useState("")
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }))
+  }
+
+  const validateEmail = async () => {
+    const newErrors = { ...errors }
+    let isValid = true
+
+    if (formData.email.trim() === "") {
+      newErrors.email = "이메일을 입력해주세요."
+      isValid = false
+    } else if (!/^[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}$/.test(formData.email)) {
+      newErrors.email = "올바른 이메일 주소를 입력해주세요."
+      isValid = false
+    } else if (formData.email.length > 100) {
+      newErrors.email = "이메일은 최대 100자 이하여야 합니다."
+      isValid = false
+    } else {
+      newErrors.email = ""
+    }
+    setErrors((prev) => ({ ...prev, email: newErrors.email }))
+    return isValid
+  }
+
+  const validateForm = async () => {
+    let isValid = true
+    isValid = (await validateEmail()) && isValid
+
+    return isValid
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!validateForm()) {
+      alert("입력하신 정보를 확인해주세요")
+      return
+    }
+
+    const requestData = {
+      email: formData.email,
+    }
+
+    proxy
+      .post(`/help/loginId`, requestData)
+      .then((res) => {
+        console.log(res.data.response.loginId)
+        setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
+        alert(`회원님의 아이디는 ${res.data.response.loginId} 입니다.`)
+      })
+      .catch((err) => {
+        console.log(err.response.data.errorMessage)
+        alert(err.response.data.errorMessage)
+      })
+  }
+  return (
+    <Modal onClickClose={onClickClose}>
+      <div className="p-5 h-0 grow max-md:p-3">
+        <form
+          className="overflow-y-scroll custom-scroll-bar-10px max-h-full -mr-[10px] max-md:custom-scroll-bar-4px max-md:-mr-[4px]"
+          onSubmit={handleSubmit}
+        >
+          <div className="flex flex-col items-center">
+            <TextField
+              label="이메일"
+              type="text"
+              name="email"
+              placeholder="가입하신 이메일을 입력해주세요."
+              required
+              onChange={(e) => {
+                limitInputNumber(e, 100)
+                handleChange(e)
+              }}
+              onBlur={() => validateEmail()}
+              error={errors.email}
+              autoComplete="email"
+              message={message}
+            />
+
+            <button
+              className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-80 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
+              type="submit"
+            >
+              아이디 찾기
+            </button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  )
+}

--- a/client/src/containers/account/findUserIdModal.tsx
+++ b/client/src/containers/account/findUserIdModal.tsx
@@ -6,7 +6,15 @@ import proxy from "@/utils/proxy"
 import TextField from "@/components/textField"
 import { limitInputNumber } from "@/utils/utils"
 
-export default function FindUserIdModal({ onClickClose }: { onClickClose(): void }) {
+export default function FindUserIdModal({
+  onClickClose,
+  setFindUserPasswordModalOpened,
+  setLoginModalOpened,
+}: {
+  onClickClose(): void
+  setFindUserPasswordModalOpened: React.Dispatch<React.SetStateAction<boolean>>
+  setLoginModalOpened: React.Dispatch<React.SetStateAction<boolean>>
+}) {
   const [formData, setFormData] = useState({
     email: "",
   })
@@ -15,6 +23,7 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
   })
   const [message, setMessage] = useState("")
   const [disable, setDisable] = useState(false)
+  const [nextButtons, setNextButtons] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -66,6 +75,7 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
       .then((res) => {
         setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
         setDisable(true)
+        setNextButtons(true)
       })
       .catch((err) => {
         alert(err.response.data.errorMessage)
@@ -97,11 +107,35 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
             />
 
             <button
-              className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-80 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
+              className={`${
+                disable ? "invisible h-0 p-0 " : "visible h-12 p-2 max-md:h-10"
+              } bg-orange-400 hover:bg-main-theme text-white font-semibold rounded w-80 max-md:w-64 max-md:font-normal`}
               type="submit"
             >
               아이디 찾기
             </button>
+            <div className={`${nextButtons ? "visble" : "invisible"} flex gap-2 max-md:flex-col`}>
+              <button
+                className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-40 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
+                type="button"
+                onClick={() => {
+                  setLoginModalOpened(true)
+                  onClickClose()
+                }}
+              >
+                로그인 하기
+              </button>
+              <button
+                className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-40 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
+                type="button"
+                onClick={() => {
+                  setFindUserPasswordModalOpened(true)
+                  onClickClose()
+                }}
+              >
+                비밀번호 초기화
+              </button>
+            </div>
           </div>
         </form>
       </div>

--- a/client/src/containers/account/findUserIdModal.tsx
+++ b/client/src/containers/account/findUserIdModal.tsx
@@ -14,6 +14,7 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
     email: "",
   })
   const [message, setMessage] = useState("")
+  const [disable, setDisable] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -50,13 +51,12 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
     return isValid
   }
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!validateForm()) {
+    if (!(await validateForm())) {
       alert("입력하신 정보를 확인해주세요")
       return
     }
-
     const requestData = {
       email: formData.email,
     }
@@ -64,12 +64,10 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
     proxy
       .post(`/help/loginId`, requestData)
       .then((res) => {
-        console.log(res.data.response.loginId)
         setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
-        alert(`회원님의 아이디는 ${res.data.response.loginId} 입니다.`)
+        setDisable(true)
       })
       .catch((err) => {
-        console.log(err.response.data.errorMessage)
         alert(err.response.data.errorMessage)
       })
   }
@@ -95,6 +93,7 @@ export default function FindUserIdModal({ onClickClose }: { onClickClose(): void
               error={errors.email}
               autoComplete="email"
               message={message}
+              disabled={disable}
             />
 
             <button

--- a/client/src/containers/account/findUserPasswordModal.tsx
+++ b/client/src/containers/account/findUserPasswordModal.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import React, { useState } from "react"
+import Modal from "@/components/modal"
+import proxy from "@/utils/proxy"
+import { limitInputNumber } from "@/utils/utils"
+import TextField from "@/components/textField"
+
+export default function FindUserPasswordModal({ onClickClose }: { onClickClose(): void }) {
+  const [formData, setFormData] = useState({
+    email: "",
+  })
+  const [errors, setErrors] = useState({
+    email: "",
+  })
+  const [message, setMessage] = useState("")
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }))
+  }
+
+  const validateEmail = async () => {
+    const newErrors = { ...errors }
+    let isValid = true
+
+    if (formData.email.trim() === "") {
+      newErrors.email = "이메일을 입력해주세요."
+      isValid = false
+    } else if (!/^[\w.%+-]+@[\w.-]+\.[A-Za-z]{2,}$/.test(formData.email)) {
+      newErrors.email = "올바른 이메일 주소를 입력해주세요."
+      isValid = false
+    } else if (formData.email.length > 100) {
+      newErrors.email = "이메일은 최대 100자 이하여야 합니다."
+      isValid = false
+    } else {
+      newErrors.email = ""
+    }
+    setErrors((prev) => ({ ...prev, email: newErrors.email }))
+    return isValid
+  }
+
+  const validateForm = async () => {
+    let isValid = true
+    isValid = (await validateEmail()) && isValid
+
+    return isValid
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!validateForm()) {
+      alert("입력하신 정보를 확인해주세요")
+      return
+    }
+
+    const requestData = {
+      email: formData.email,
+    }
+
+    proxy.post(`/help/loginId`, requestData).then((res) => {
+      console.log(res.data.response.loginId)
+      setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
+      alert(`회원님의 아이디는 ${res.data.response.loginId} 입니다.`)
+    })
+  }
+  return (
+    <Modal onClickClose={onClickClose}>
+      <div className="p-5 h-0 grow max-md:p-3">
+        <form
+          className="overflow-y-scroll custom-scroll-bar-10px max-h-full -mr-[10px] max-md:custom-scroll-bar-4px max-md:-mr-[4px]"
+          onSubmit={handleSubmit}
+        >
+          <div className="flex flex-col items-center">
+            <TextField
+              label="이메일"
+              type="text"
+              name="email"
+              placeholder="가입하신 이메일을 입력해주세요."
+              required
+              onChange={(e) => {
+                limitInputNumber(e, 100)
+                handleChange(e)
+              }}
+              onBlur={() => validateEmail()}
+              error={errors.email}
+              autoComplete="email"
+              message={message}
+            />
+
+            <button
+              className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-80 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
+              type="submit"
+            >
+              아이디 찾기
+            </button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  )
+}

--- a/client/src/containers/account/findUserPasswordModal.tsx
+++ b/client/src/containers/account/findUserPasswordModal.tsx
@@ -6,7 +6,13 @@ import proxy from "@/utils/proxy"
 import { limitInputNumber } from "@/utils/utils"
 import TextField from "@/components/textField"
 
-export default function FindUserPasswordModal({ onClickClose }: { onClickClose(): void }) {
+export default function FindUserPasswordModal({
+  onClickClose,
+  setLoginModalOpened,
+}: {
+  onClickClose(): void
+  setLoginModalOpened: React.Dispatch<React.SetStateAction<boolean>>
+}) {
   const [formData, setFormData] = useState({
     loginId: "",
     email: "",
@@ -15,7 +21,6 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
     loginId: "",
     email: "",
   })
-  const [message, setMessage] = useState("")
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -32,6 +37,8 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
     if (formData.loginId.trim() === "") {
       newErrors.loginId = "아이디를 입력해주세요."
       isValid = false
+    } else {
+      newErrors.loginId = ""
     }
 
     setErrors((prev) => ({ ...prev, loginId: newErrors.loginId }))
@@ -78,11 +85,24 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
       email: formData.email,
     }
 
-    proxy.post(`/help/password`, requestData).then((res) => {
-      console.log(res.data.response.loginId)
-      setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
-      alert(`회원님의 아이디는 ${res.data.response.loginId} 입니다.`)
-    })
+    if (
+      confirm(
+        "비밀번호를 초기화 하시겠습니까?" +
+          "\n초기화된 비밀번호는 아이디와 연동된 이메일로 전송됩니다." +
+          "\n전송된 비밀번호로 로그인 후 비밀번호를 변경해주세요.",
+      )
+    ) {
+      proxy
+        .post(`/help/password`, requestData, undefined)
+        .then(() => {
+          alert("비밀번호가 초기화 되었습니다.\n이메일을 확인해주세요.")
+          onClickClose()
+          setLoginModalOpened(true)
+        })
+        .catch(() => {
+          alert("입력하신 정보를 확인해주세요")
+        })
+    }
   }
   return (
     <Modal onClickClose={onClickClose}>

--- a/client/src/containers/account/findUserPasswordModal.tsx
+++ b/client/src/containers/account/findUserPasswordModal.tsx
@@ -8,9 +8,11 @@ import TextField from "@/components/textField"
 
 export default function FindUserPasswordModal({ onClickClose }: { onClickClose(): void }) {
   const [formData, setFormData] = useState({
+    loginId: "",
     email: "",
   })
   const [errors, setErrors] = useState({
+    loginId: "",
     email: "",
   })
   const [message, setMessage] = useState("")
@@ -21,6 +23,19 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
       ...prevData,
       [name]: value,
     }))
+  }
+
+  const validateLoginId = async () => {
+    const newErrors = { ...errors }
+    let isValid = true
+
+    if (formData.loginId.trim() === "") {
+      newErrors.loginId = "아이디를 입력해주세요."
+      isValid = false
+    }
+
+    setErrors((prev) => ({ ...prev, loginId: newErrors.loginId }))
+    return isValid
   }
 
   const validateEmail = async () => {
@@ -46,22 +61,24 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
   const validateForm = async () => {
     let isValid = true
     isValid = (await validateEmail()) && isValid
+    isValid = (await validateLoginId()) && isValid
 
     return isValid
   }
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!validateForm()) {
+    if (!(await validateForm())) {
       alert("입력하신 정보를 확인해주세요")
       return
     }
 
     const requestData = {
+      loginId: formData.loginId,
       email: formData.email,
     }
 
-    proxy.post(`/help/loginId`, requestData).then((res) => {
+    proxy.post(`/help/password`, requestData).then((res) => {
       console.log(res.data.response.loginId)
       setMessage(`회원님의 아이디는 '${res.data.response.loginId}' 입니다.`)
       alert(`회원님의 아이디는 ${res.data.response.loginId} 입니다.`)
@@ -76,6 +93,20 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
         >
           <div className="flex flex-col items-center">
             <TextField
+              label="아이디"
+              type="text"
+              name="loginId"
+              placeholder="아이디를 입력하세요"
+              required
+              onChange={(e) => {
+                limitInputNumber(e, 40)
+                handleChange(e)
+              }}
+              onBlur={() => validateLoginId()}
+              error={errors.loginId}
+              autoComplete="username"
+            />
+            <TextField
               label="이메일"
               type="text"
               name="email"
@@ -88,14 +119,13 @@ export default function FindUserPasswordModal({ onClickClose }: { onClickClose()
               onBlur={() => validateEmail()}
               error={errors.email}
               autoComplete="email"
-              message={message}
             />
 
             <button
               className="bg-orange-400 hover:bg-main-theme text-white font-semibold p-2 rounded w-80 h-12 max-md:w-64 max-md:h-10 max-md:font-normal"
               type="submit"
             >
-              아이디 찾기
+              비밀번호 초기화
             </button>
           </div>
         </form>

--- a/client/src/containers/account/loginModal.tsx
+++ b/client/src/containers/account/loginModal.tsx
@@ -8,7 +8,17 @@ import { AuthContext } from "@/contexts/authContextProvider"
 import TextField from "@/components/textField"
 import { limitInputNumber } from "@/utils/utils"
 
-export default function LoginModal({ onClickClose, onClickJoin }: { onClickClose(): void; onClickJoin(): void }) {
+export default function LoginModal({
+  onClickClose,
+  onClickJoin,
+  onClickFindId,
+  onClickFindPassword,
+}: {
+  onClickClose(): void
+  onClickJoin(): void
+  onClickFindId(): void
+  onClickFindPassword(): void
+}) {
   const { needUpdate } = useContext(AuthContext)
   const [formData, setFormData] = useState({
     loginId: "",
@@ -115,6 +125,16 @@ export default function LoginModal({ onClickClose, onClickJoin }: { onClickClose
                 <p className="max-md:text-xs mr-2">계정이 없으신가요?</p>
                 <button type="button" onClick={onClickJoin}>
                   <p className="max-md:text-xs underline">회원가입하기</p>
+                </button>
+              </div>
+            </div>
+            <div>
+              <div className="flex mt-3 gap-2">
+                <button type="button" onClick={onClickFindId}>
+                  <p className="max-md:text-xs underline">아이디 찾기 </p>
+                </button>
+                <button type="button" onClick={onClickFindPassword}>
+                  <p className="max-md:text-xs underline">비밀번호 찾기</p>
                 </button>
               </div>
             </div>

--- a/client/src/containers/account/loginModal.tsx
+++ b/client/src/containers/account/loginModal.tsx
@@ -134,7 +134,7 @@ export default function LoginModal({
                   <p className="max-md:text-xs underline">아이디 찾기 </p>
                 </button>
                 <button type="button" onClick={onClickFindPassword}>
-                  <p className="max-md:text-xs underline">비밀번호 찾기</p>
+                  <p className="max-md:text-xs underline">비밀번호 초기화</p>
                 </button>
               </div>
             </div>

--- a/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(authorize ->
                         authorize.requestMatchers("/api/chatrooms/**").hasRole("USER")
                                 .requestMatchers("/api/email-verifications/**", "/api/users/**").hasAnyRole("PENDING", "USER")
-                                .requestMatchers("/api/validate/**").permitAll()
+                                .requestMatchers("/api/validate/**", "/api/help/**").permitAll()
                                 .anyRequest().permitAll()
         );
 

--- a/server/src/main/java/net/chatfoodie/server/_core/utils/Utils.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/utils/Utils.java
@@ -1,15 +1,19 @@
 package net.chatfoodie.server._core.utils;
 
+import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
+import net.chatfoodie.server._core.config.MailConfig;
 import net.chatfoodie.server._core.errors.exception.Exception500;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.JavaMailSender;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.format.FormatStyle;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
 @Slf4j
 public class Utils {
@@ -44,5 +48,40 @@ public class Utils {
             return day <= dayOfLeapYear;
         }
         return day <= dayByMonth.get(month - 1);
+    }
+
+    public static String generateRandomPassword() {
+        Random random = new Random();
+
+        String PASSWORD_ALLOW_BASE = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&";
+        Integer PASSWORD_LENGTH = 16;
+
+        String password = "";
+
+        for (int i = 0; i < PASSWORD_LENGTH; i++) {
+            int rndCharAt = random.nextInt(PASSWORD_ALLOW_BASE.length());
+            char rndChar = PASSWORD_ALLOW_BASE.charAt(rndCharAt);
+            password += rndChar;
+        }
+
+        return password;
+    }
+
+    public static void sendEmail(JavaMailSender javaMailSender, String to, String subject, String text) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(text, true);
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            StackTraceElement[] err = e.getStackTrace();
+            for (StackTraceElement stackTraceElement: err
+                 ) {
+                log.error(stackTraceElement.toString());
+            }
+            throw new Exception500("서버 이메일 전송 한도가 초과되었습니다. 내일 다시 시도해주세요.");
+        }
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -7,6 +7,7 @@ import net.chatfoodie.server._core.errors.exception.Exception400;
 import net.chatfoodie.server._core.errors.exception.Exception404;
 import net.chatfoodie.server._core.errors.exception.Exception500;
 import net.chatfoodie.server._core.security.JwtProvider;
+import net.chatfoodie.server._core.utils.Utils;
 import net.chatfoodie.server.emailVerification.EmailVerification;
 import net.chatfoodie.server.emailVerification.dto.EmailVerificationRequest;
 import net.chatfoodie.server.emailVerification.repository.EmailVerificationRepository;
@@ -14,7 +15,6 @@ import net.chatfoodie.server.user.Role;
 import net.chatfoodie.server.user.User;
 import net.chatfoodie.server.user.repository.UserRepository;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,16 +66,7 @@ public class EmailVerificationService {
         String subject = "chatfoodie 이메일 인증번호입니다.";
         String text = "이메일 인증을 위한 인증번호는 " + code + "입니다. </br>";
 
-        try {
-            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
-            helper.setTo(email);
-            helper.setSubject(subject);
-            helper.setText(text, true);
-            javaMailSender.send(mimeMessage);
-        } catch (Exception e) {
-            throw new Exception500("서버 이메일 전송 한도가 초과되었습니다. 내일 다시 시도해주세요.");
-        }
+        Utils.sendEmail(javaMailSender, email, subject, text);
     }
 
     @Transactional

--- a/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
@@ -79,6 +79,13 @@ public class UserController {
         ApiUtils.Response<?> response = ApiUtils.success();
         return ResponseEntity.ok().body(response);
     }
+
+    @PostMapping("/help/loginId")
+    public ResponseEntity<?> findUserId(@RequestBody @Valid UserRequest.FindUserIdDto requestDto) {
+        UserResponse.FindUserIdDto responseDto = userService.findUserId(requestDto);
+        ApiUtils.Response<?> response = ApiUtils.success(responseDto);
+        return ResponseEntity.ok().body(response);
+    }
     @PostMapping("/validate/loginId")
     public ResponseEntity<?> validateLoginId(@RequestBody @Valid UserRequest.ValidateLoginIdDto requestDto,
                                              Errors errors) {

--- a/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
@@ -81,9 +81,16 @@ public class UserController {
     }
 
     @PostMapping("/help/loginId")
-    public ResponseEntity<?> findUserId(@RequestBody @Valid UserRequest.FindUserIdDto requestDto) {
+    public ResponseEntity<?> findUserId(@RequestBody @Valid UserRequest.FindUserIdDto requestDto, Errors errors) {
         UserResponse.FindUserIdDto responseDto = userService.findUserId(requestDto);
         ApiUtils.Response<?> response = ApiUtils.success(responseDto);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/help/password")
+    public ResponseEntity<?> resetPassword(@RequestBody @Valid UserRequest.ResetPasswordDto requestDto, Errors errors) {
+        userService.resetPassword(requestDto);
+        ApiUtils.Response<?> response = ApiUtils.success();
         return ResponseEntity.ok().body(response);
     }
     @PostMapping("/validate/loginId")

--- a/server/src/main/java/net/chatfoodie/server/user/dto/UserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/user/dto/UserRequest.java
@@ -77,4 +77,9 @@ public class UserRequest {
     public record FindUserIdDto(
             String email
     ) {}
+
+    public record ResetPasswordDto(
+            String loginId,
+            String email
+    ) {}
 }

--- a/server/src/main/java/net/chatfoodie/server/user/dto/UserRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/user/dto/UserRequest.java
@@ -74,4 +74,7 @@ public class UserRequest {
             String email
     ) {}
 
+    public record FindUserIdDto(
+            String email
+    ) {}
 }

--- a/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
@@ -42,6 +42,9 @@ public class UserResponse {
     public record FindUserIdDto(
             String loginId
     ) {
+        public FindUserIdDto(String loginId) {
+            this.loginId = loginId.substring(0,2) + "***" + loginId.substring(loginId.length()-1, loginId.length());
+        }
 
     }
 

--- a/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
@@ -39,4 +39,10 @@ public class UserResponse {
         }
     }
 
+    public record FindUserIdDto(
+            String loginId
+    ) {
+
+    }
+
 }

--- a/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
@@ -3,13 +3,11 @@ package net.chatfoodie.server.user.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server._core.errors.exception.*;
-import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server._core.utils.Utils;
 import net.chatfoodie.server.chatroom.Chatroom;
 import net.chatfoodie.server.chatroom.message.repository.MessageRepository;
 import net.chatfoodie.server.chatroom.repository.ChatroomRepository;
-import net.chatfoodie.server.chatroom.service.ChatroomService;
 import net.chatfoodie.server.favor.Favor;
 import net.chatfoodie.server.favor.repository.FavorRepository;
 import net.chatfoodie.server.user.Role;
@@ -17,7 +15,6 @@ import net.chatfoodie.server.user.dto.UserRequest;
 import net.chatfoodie.server.user.User;
 import net.chatfoodie.server.user.dto.UserResponse;
 import net.chatfoodie.server.user.repository.UserRepository;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -149,5 +146,11 @@ public class UserService {
         if (userRepository.findByEmail(requestDto.email()).isPresent()) {
             throw new EmailAlreadyExistException("이미 존재하는 이메일입니다.");
         }
+    }
+
+    public UserResponse.FindUserIdDto findUserId(UserRequest.FindUserIdDto requestDto) {
+        User user = userRepository.findByEmail(requestDto.email()).orElseThrow(() -> new Exception404("존재하지 않는 사용자입니다."));
+
+        return new UserResponse.FindUserIdDto(user.getLoginId());
     }
 }


### PR DESCRIPTION
## Summary

선호 음식이 없는 회원이 로그인 시, 선호 음식 저장 창을 띄웁니다.

아이디와 비밀번호를 잊었을 때 찾거나, 초기화 할 수 있게 도와 줍니다.

## Description

선호 음식을 고르게 하는 이유는 더 개인화된 서비스를 제공하기 위해서 입니다.

아이디 찾기는 가입한 이메일을 통해 찾을 수 있으며, 일치하는 아이디가 있을 시, 화면에 나타냅니다. (예- 만약 아이디가 username이면, us***e로 출력)

비밀번호 초기화는 가입한 아이디와 이메일을 통해 비밀번호를 초기화 합니다. 초기화된 비밀번호는 이메일을 통해 전달됩니다. 이후 초기화된 비밀번호로 로그인 후, 원하는 비밀번호로 초기화 하면 됩니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
close: #151 
close: #152
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->