### PR TITLE
stopping_strings 적용 및 답변 재생성 ui 버그 수정

### DIFF
--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -39,43 +39,33 @@ export default function ChatUi() {
     })
   }
 
-  const handleStreamMessage = async (message: string, chatroomIdToSend: number) => {
-    const finishStreaming = message === ""
+  const handleStreamMessage = async (message: string) => {
+    setMessages((prevState) => {
+      const lastMessage = prevState[prevState.length - 1]
+      if (lastMessage && lastMessage.isFromChatbot) {
+        lastMessage.content = message
+        return [...prevState.slice(0, -1), lastMessage]
+      }
+      const chatMessage: ChatMessage = {
+        key: 0,
+        content: message,
+        isFromChatbot: true,
+      }
+      return [...prevState, ...toChatMessageFormat([chatMessage])]
+    })
+  }
 
-    if (!finishStreaming) {
-      setMessages((prevState) => {
-        const lastMessage = prevState[prevState.length - 1]
-        if (lastMessage && lastMessage.isFromChatbot) {
-          lastMessage.content = message
-          return [...prevState.slice(0, -1), lastMessage]
-        }
-        const chatMessage: ChatMessage = {
-          key: 0,
-          content: message,
-          isFromChatbot: true,
-        }
-        return [...prevState, ...toChatMessageFormat([chatMessage])]
-      })
-    } else if (userId !== 0) {
-      const headers = { Authorization: getJwtTokenFromStorage() }
-      const params = { size: 2 }
-      const res = await proxy.get(`/chatrooms/${chatroomIdToSend}/messages`, { headers, params })
-
-      const newMessages: ChatMessage[] = res.data.response.body.messages
-
-      setMessages((prevState) => {
-        const keyOfNeedToSync = prevState.filter((m) => m.id === undefined).map((m) => m.key)
-
-        const messagesToAdd = newMessages
-          .filter((m) => !prevState.map((prev) => prev.id).includes(m.id))
-          .map((m, index) => {
-            const ret = m
-            ret.key = keyOfNeedToSync[index]
-            return ret
-          })
-        return [...prevState.filter((m) => m.id), ...messagesToAdd]
-      })
-    }
+  const handleStreamEndWhichCaseUser = (id: number, regenerate: boolean) => {
+    setMessages((prevState) => {
+      const chatbotMessage = prevState[prevState.length - 1]
+      chatbotMessage.id = id
+      if (regenerate) {
+        return [...prevState.slice(0, -1), chatbotMessage]
+      }
+      const userMessage = prevState[prevState.length - 2]
+      userMessage.id = id
+      return [...prevState.slice(0, -2), userMessage, chatbotMessage]
+    })
   }
 
   const prepareRegenerate = () => {
@@ -136,6 +126,7 @@ export default function ChatUi() {
       <MessageInputContainer
         messages={messages}
         handleStreamMessage={handleStreamMessage}
+        handleStreamEndWhichCaseUser={handleStreamEndWhichCaseUser}
         addUserMessage={(message: string) => addMessage(message, false)}
         prepareRegenerate={prepareRegenerate}
       />

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -55,15 +55,15 @@ export default function ChatUi() {
     })
   }
 
-  const handleStreamEndWhichCaseUser = (id: number, regenerate: boolean) => {
+  const handleStreamEndWhichCaseUser = (userMessageId: number, chatbotMessageId: number, regenerate: boolean) => {
     setMessages((prevState) => {
       const chatbotMessage = prevState[prevState.length - 1]
-      chatbotMessage.id = id
+      chatbotMessage.id = chatbotMessageId
       if (regenerate) {
         return [...prevState.slice(0, -1), chatbotMessage]
       }
       const userMessage = prevState[prevState.length - 2]
-      userMessage.id = id
+      userMessage.id = userMessageId
       return [...prevState.slice(0, -2), userMessage, chatbotMessage]
     })
   }

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -19,7 +19,7 @@ export default function MessageInputContainer({
   handleStreamMessage: (message: string) => void
   addUserMessage: (message: string) => void
   prepareRegenerate: () => void
-  handleStreamEndWhichCaseUser: (id: number, regenerate: boolean) => void
+  handleStreamEndWhichCaseUser: (userMessageId: number, chatbotMessageId: number, regenerate: boolean) => void
 }) {
   const [isGenerating, setIsGenerating] = useState(false)
 
@@ -113,7 +113,11 @@ export default function MessageInputContainer({
         }
         case "stream_end":
           if (userId !== 0) {
-            handleStreamEndWhichCaseUser(Number(res.response), regenerate)
+            handleStreamEndWhichCaseUser(
+              Number(res.response.userMessageId),
+              Number(res.response.chatbotMessageId),
+              regenerate,
+            )
           }
           break
         case "error":

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -13,11 +13,13 @@ export default function MessageInputContainer({
   handleStreamMessage,
   addUserMessage,
   prepareRegenerate,
+  handleStreamEndWhichCaseUser,
 }: {
   messages: ChatMessage[]
-  handleStreamMessage: (message: string, chatroomIdToSend: number) => void
+  handleStreamMessage: (message: string) => void
   addUserMessage: (message: string) => void
   prepareRegenerate: () => void
+  handleStreamEndWhichCaseUser: (id: number, regenerate: boolean) => void
 }) {
   const [isGenerating, setIsGenerating] = useState(false)
 
@@ -106,11 +108,13 @@ export default function MessageInputContainer({
       const res = JSON.parse(event.data)
       switch (res.event) {
         case "text_stream": {
-          handleStreamMessage(res.response, chatroomIdToSend)
+          handleStreamMessage(res.response)
           return
         }
         case "stream_end":
-          handleStreamMessage("", chatroomIdToSend)
+          if (userId !== 0) {
+            handleStreamEndWhichCaseUser(Number(res.response), regenerate)
+          }
           break
         case "error":
           alert(res.response)

--- a/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
@@ -1,6 +1,0 @@
-package net.chatfoodie.server._core.utils;
-
-@FunctionalInterface
-public interface MyFunction {
-    Long apply(String message);
-}

--- a/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/utils/MyFunction.java
@@ -2,5 +2,5 @@ package net.chatfoodie.server._core.utils;
 
 @FunctionalInterface
 public interface MyFunction {
-    void apply(String message);
+    Long apply(String message);
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatFoodieRequest.java
@@ -1,5 +1,6 @@
 package net.chatfoodie.server.chat.dto;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ChatFoodieRequest {
@@ -12,6 +13,13 @@ public class ChatFoodieRequest {
     private static final Float REPETITION_PENALTY = 1.15f;
     private static final Float TOP_K = 20.0f;
     private static final Boolean EARLY_STOPPING = false;
+    private static final List<String> STOPPING_STRINGS = Collections.unmodifiableList(
+            List.of(
+                    "\n###",
+                    "\n답변:",
+                    "\n고객:"
+            )
+    );
 
     public record MessageDto(
             String user_input,
@@ -25,7 +33,8 @@ public class ChatFoodieRequest {
             Float top_p,
             Float repetition_penalty,
             Float top_k,
-            Boolean early_stopping
+            Boolean early_stopping,
+            List<String> stopping_strings
     ) {
 
         public MessageDto(ChatUserRequest.PublicMessageDto userPublicMessageDto) {
@@ -41,7 +50,8 @@ public class ChatFoodieRequest {
                     TOP_P,
                     REPETITION_PENALTY,
                     TOP_K,
-                    EARLY_STOPPING
+                    EARLY_STOPPING,
+                    STOPPING_STRINGS
             );
         }
 
@@ -58,7 +68,8 @@ public class ChatFoodieRequest {
                     TOP_P,
                     REPETITION_PENALTY,
                     TOP_K,
-                    EARLY_STOPPING
+                    EARLY_STOPPING,
+                    STOPPING_STRINGS
             );
         }
 

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/ChatUserResponse.java
@@ -18,4 +18,23 @@ public class ChatUserResponse {
             );
         }
     }
+
+    public record MessageEndDto(
+            String event,
+            ResponseDto response
+    ) {
+
+        public MessageEndDto(Long userMessageId, Long chatbotMessageId) {
+            this(
+                    "stream_end",
+                    new ResponseDto(userMessageId, chatbotMessageId)
+            );
+        }
+
+        public record ResponseDto(
+                Long userMessageId,
+                Long chatbotMessageId
+        ) {
+        }
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/chat/dto/MessageIds.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/dto/MessageIds.java
@@ -1,0 +1,4 @@
+package net.chatfoodie.server.chat.dto;
+
+public record MessageIds(Long userMessageId, Long chatbotMessageId) {
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server._core.errors.exception.Exception500;
-import net.chatfoodie.server._core.utils.MyFunction;
 import net.chatfoodie.server.chat.dto.ChatFoodieResponse;
 import net.chatfoodie.server.chat.dto.ChatUserResponse;
 import net.chatfoodie.server.chat.handler.FoodieWebSocketHandler;
@@ -55,8 +54,8 @@ public class FoodieWebSocketService {
                         var userMessageDto = new ChatUserResponse.MessageDto(foodieMessageDto);
 
                         if (isStreamEndEvent(foodieMessageDto)) {
-                            var resultId = function.apply(finalResponse);
-                            var endMessageDto = new ChatUserResponse.MessageDto(foodieMessageDto.event(), resultId.toString());
+                            var messageIds = function.apply(finalResponse);
+                            var endMessageDto = new ChatUserResponse.MessageEndDto(messageIds.userMessageId(), messageIds.chatbotMessageId());
                             TextMessage textMessage = new TextMessage(om.writeValueAsString(endMessageDto));
 
                             user.sendMessage(textMessage);

--- a/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/FoodieWebSocketService.java
@@ -54,14 +54,18 @@ public class FoodieWebSocketService {
 
                         var userMessageDto = new ChatUserResponse.MessageDto(foodieMessageDto);
 
+                        if (isStreamEndEvent(foodieMessageDto)) {
+                            var resultId = function.apply(finalResponse);
+                            var endMessageDto = new ChatUserResponse.MessageDto(foodieMessageDto.event(), resultId.toString());
+                            TextMessage textMessage = new TextMessage(om.writeValueAsString(endMessageDto));
+
+                            user.sendMessage(textMessage);
+                            break;
+                        }
                         TextMessage textMessage = new TextMessage(om.writeValueAsString(userMessageDto));
 
                         user.sendMessage(textMessage);
 
-                        if (isStreamEndEvent(foodieMessageDto)) {
-                            function.apply(finalResponse);
-                            break;
-                        }
                         finalResponse = userMessageDto.response();
                     } catch (InterruptedException e) {
                         throw new Exception500("챗봇의 응답을 듣는 중 에러가 발생했습니다.");

--- a/server/src/main/java/net/chatfoodie/server/chat/service/MyFunction.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/MyFunction.java
@@ -1,0 +1,9 @@
+package net.chatfoodie.server.chat.service;
+
+
+import net.chatfoodie.server.chat.dto.MessageIds;
+
+@FunctionalInterface
+public interface MyFunction {
+    MessageIds apply(String message);
+}

--- a/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
+++ b/server/src/main/java/net/chatfoodie/server/chat/service/UserWebSocketService.java
@@ -1,17 +1,14 @@
 package net.chatfoodie.server.chat.service;
 
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server._core.errors.exception.Exception400;
 import net.chatfoodie.server._core.errors.exception.Exception403;
 import net.chatfoodie.server._core.errors.exception.Exception404;
 import net.chatfoodie.server._core.errors.exception.Exception500;
-import net.chatfoodie.server._core.security.CustomUserDetails;
 import net.chatfoodie.server._core.security.JwtProvider;
 import net.chatfoodie.server._core.utils.MyFunction;
 import net.chatfoodie.server.chat.dto.ChatFoodieRequest;
@@ -26,11 +23,9 @@ import net.chatfoodie.server.chatroom.repository.ChatroomRepository;
 import net.chatfoodie.server.favor.Favor;
 import net.chatfoodie.server.favor.repository.FavorRepository;
 import net.chatfoodie.server.food.Food;
-import net.chatfoodie.server.user.Role;
 import net.chatfoodie.server.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.TextMessage;
@@ -80,22 +75,21 @@ public class UserWebSocketService {
                 Message oldMessage = messageRepository.findTop1ByChatroomIdOrderByIdDesc(chatroomId).orElse(null);
                 if (oldMessage != null && oldMessage.isFromChatbot()) {
                     oldMessage.updateContent(message);
-                    messageRepository.save(oldMessage);
-                    return;
+                    return messageRepository.save(oldMessage).getId();
                 }
                 Message chatbotMessage = Message.builder()
                         .chatroom(chatroom)
                         .isFromChatbot(true)
                         .content(message)
                         .build();
-                messageRepository.save(chatbotMessage);
+                return messageRepository.save(chatbotMessage).getId();
             } : message -> {
                 Message chatbotMessage = Message.builder()
                         .chatroom(chatroom)
                         .isFromChatbot(true)
                         .content(message)
                         .build();
-                messageRepository.save(chatbotMessage);
+            return messageRepository.save(chatbotMessage).getId();
             }
         );
     }
@@ -117,6 +111,7 @@ public class UserWebSocketService {
                     .build();
             chatPublicLogRepository.save(chatLog);
             log.debug("public api 마지막 전달 완료!!\n" + message);
+            return 0L;
         });
     }
 


### PR DESCRIPTION
## Summary

버그들을 해결했습니다.

## Description

stopping_strings의 경우 적용이 잘 되지 않아 챗봇 서버 코드를 디버깅해보았습니다.

그 결과, 사용하는 캐릭터(persona) 스트리밍 api의 경우, 파라미터의 stopping_strings를 적용하지 않고 있는 모습을 발견하였습니다. 따라서 chat-foodie-chatbot-server 쪽 코드를 수정함으로써 정상 작동하도록하였습니다.

저희 서버 쪽 코드는 단순히 requestDTO에 스트링 배열을 추가하였습니다.

---

그 외 답변 재생성 시 스트리밍 중인 메시지가 스트리밍이 끝난후 db에 저장된 메시지로 id 값을 갱신하여 synchronize하는 과정에서 아직 db에 반영하기 직전에 먼저 접근하여 이전 메시지로 확인하여 재생성 후 이전 답변이 출력이 되는 버그가 존재했습니다.

이를 해결하기 위해 stream_end 이벤트의 response로 db에 저장한 id들(사용자의 메시지 id, 챗봇의 메시지 id)을 응답에 포함하여 전달합니다. 클라이언트에서는 이 응답의 id로 id만을 갱신합니다.

이상으로 2가지 문제 해결하였습니다. 추가적인 작업으로 챗봇 서버 쪽 코드를 갱신하여 개선 사항 반영이 필요합니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #162 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->