### PR TITLE
redis를 사용한 Refresh Token 전략 추가

### DIFF
--- a/client/src/containers/account/account.tsx
+++ b/client/src/containers/account/account.tsx
@@ -30,10 +30,7 @@ export default function Account() {
 
   useEffect(() => {
     if (userId !== 0) {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
-      proxy.get(`/users/${userId}`, { headers }).then((res) => {
+      proxy.get(`/users/${userId}`).then((res) => {
         setUserName(res.data.response.name)
         if (userRole === "ROLE_USER" && res.data.response.favors.length === 0) {
           setPreferenceModalOpened(true)

--- a/client/src/containers/account/dropDown.tsx
+++ b/client/src/containers/account/dropDown.tsx
@@ -88,7 +88,7 @@ export default function DropDown({
           type="button"
           className="flex flex-row gap-4 items-center justify-center text-sm text-center font-bold w-full h-[36px] p-3 min-h-[40px] hover:bg-gray-300 transition-all duration-300"
           onClick={() => {
-            deleteJwt()
+            proxy.post("/logout").then(() => deleteJwt())
             needUpdate()
             setIsOpened(false)
           }}

--- a/client/src/containers/account/dropDown.tsx
+++ b/client/src/containers/account/dropDown.tsx
@@ -20,11 +20,8 @@ export default function DropDown({
 
   const handleWithdraw = () => {
     if (confirm("정말로 탈퇴하시겠습니까? \n탈퇴 시 모든 정보가 삭제됩니다. \n삭제된 정보는 복구할 수 없습니다.")) {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
       proxy
-        .delete(`/users/${userId}`, { headers })
+        .delete(`/users/${userId}`)
         .then(() => {
           deleteJwt()
           needUpdate()

--- a/client/src/containers/account/editProfileModal.tsx
+++ b/client/src/containers/account/editProfileModal.tsx
@@ -199,18 +199,14 @@ export default function EditProfileModal({
     }
 
     if (userId !== 0) {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
       const requestData = makeRequestData()
-
       proxy
-        .put(`/users/${userId}`, requestData, { headers })
+        .put(`/users/${userId}`, requestData)
         .then(() => {
           alert("수정이 완료되었습니다")
           onClickClose()
           needUpdate()
-          proxy.get(`/users/${userId}`, { headers }).then((res) => {
+          proxy.get(`/users/${userId}`).then((res) => {
             setUserName(res.data.response.name)
           })
         })
@@ -222,11 +218,7 @@ export default function EditProfileModal({
 
   useEffect(() => {
     if (userId !== 0) {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
-
-      proxy.get(`/users/${userId}`, { headers }).then((res) => {
+      proxy.get(`/users/${userId}`).then((res) => {
         setProfile({
           loginId: res.data.response.loginId,
           password: "",

--- a/client/src/containers/account/emailVerificationModal.tsx
+++ b/client/src/containers/account/emailVerificationModal.tsx
@@ -20,15 +20,11 @@ export default function EmailVerificationModal({ onClickClose }: { onClickClose(
   const [verificationCode, setVerificationCode] = useState("")
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
     const requestData = {
       verificationCode: e.currentTarget.querySelector<HTMLInputElement>(`[name='emailVerificationCode']`)!.value,
     }
     proxy
-      .post("/email-verifications/confirm", requestData, { headers })
+      .post("/email-verifications/confirm", requestData)
       .then((res) => {
         const jwt = res.headers.authorization
         saveJwt(jwt)
@@ -44,13 +40,10 @@ export default function EmailVerificationModal({ onClickClose }: { onClickClose(
   }
 
   const sendVerificationCode = () => {
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
     setDisableButton(true)
     setMessage("인증 코드 전송 중")
     proxy
-      .post("/email-verifications", undefined, { headers })
+      .post("/email-verifications")
       .then(() => {
         setDisableButton(false)
         setMessage("인증 코드 전송 완료")
@@ -123,14 +116,10 @@ export default function EmailVerificationModal({ onClickClose }: { onClickClose(
     if (userRole !== "ROLE_PENDING") {
       if (!confirm("이메일 변경하면 인증하기 전까지 로그인할 수 없습니다.\n 변경하시겠습니까?")) return
     }
-
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
     const requestData = {
       email: modifiedEmail,
     }
-    proxy.put(`/users/${userId}`, requestData, { headers }).then((res) => {
+    proxy.put(`/users/${userId}`, requestData).then((res) => {
       setEmail(modifiedEmail)
       setModifyMessage("이메일 변경 완료")
       sendVerificationCode()
@@ -141,10 +130,7 @@ export default function EmailVerificationModal({ onClickClose }: { onClickClose(
   }
 
   useEffect(() => {
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
-    proxy.get(`/users/${userId}`, { headers }).then((res) => {
+    proxy.get(`/users/${userId}`).then((res) => {
       setEmail(res.data.response.email)
       setModifiedEmail(res.data.response.email)
     })

--- a/client/src/containers/account/preferenceModal.tsx
+++ b/client/src/containers/account/preferenceModal.tsx
@@ -23,15 +23,12 @@ export default function PreferenceModal({ onClickClose }: { onClickClose(): void
   }
 
   const handleSendSelection = () => {
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
     const requestData = {
       foodIds: selectedFoods,
     }
 
     proxy
-      .post("/favors", requestData, { headers })
+      .post("/favors", requestData)
       .then(() => {
         alert("선호하는 음식이 저장되었습니다!")
         onClickClose()

--- a/client/src/containers/account/profileModal.tsx
+++ b/client/src/containers/account/profileModal.tsx
@@ -35,10 +35,7 @@ export default function ProfileModal({
   })
 
   useEffect(() => {
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
-    proxy.get(`/users/${getJwtId()}`, { headers }).then((res) => {
+    proxy.get(`/users/${getJwtId()}`).then((res) => {
       const { response } = res.data
 
       const favorsString = response.favors.map((favor: { id: number; foodName: string }) => favor.foodName).join(", ")

--- a/client/src/containers/chat/chat-ui.tsx
+++ b/client/src/containers/chat/chat-ui.tsx
@@ -75,12 +75,11 @@ export default function ChatUi() {
   const getMessages = useCallback(
     (_cursor: Cursor) => {
       if (_cursor.key === -1) return
-      const headers = { Authorization: getJwtTokenFromStorage() }
       const params = {
         // ..._cursor
       }
       proxy
-        .get(`/chatrooms/${chatroomId}/messages`, { headers, params })
+        .get(`/chatrooms/${chatroomId}/messages`, { params })
         .then((res) => {
           const patchedMessages = res.data.response.body.messages
           if (_cursor.key === undefined) {

--- a/client/src/containers/chat/message-input-container.tsx
+++ b/client/src/containers/chat/message-input-container.tsx
@@ -71,10 +71,7 @@ export default function MessageInputContainer({
       url += `/chat?token=${getJwtTokenFromStorage()}`
 
       if (chatroomIdToSend === 0) {
-        const headers = {
-          Authorization: getJwtTokenFromStorage(),
-        }
-        const res = await proxy.post("/chatrooms", undefined, { headers })
+        const res = await proxy.post("/chatrooms")
         chatroomIdToSend = res.data.response.chatroomId
         setChatroomId(chatroomIdToSend)
       }

--- a/client/src/containers/home/createChatRoomButton.tsx
+++ b/client/src/containers/home/createChatRoomButton.tsx
@@ -12,10 +12,7 @@ export default function CreateChatRoomButton({ onClickInnerButton }: { onClickIn
   const { setChatroomId } = useContext(ChatroomContext)
   const createNewChatroom = async () => {
     try {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
-      const response = await proxy.post("/chatrooms", {}, { headers })
+      const response = await proxy.post("/chatrooms")
       // 새로운 채팅방으로 이동
       setChatroomId(response.data.response.chatroomId)
     } catch (error) {

--- a/client/src/containers/home/deleteAllChatroomButton.tsx
+++ b/client/src/containers/home/deleteAllChatroomButton.tsx
@@ -15,17 +15,14 @@ export default function DeleteAllChatroomButton() {
   const handleDeleteAllChatRooms = async () => {
     setChatroomId(0)
     try {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
       // Use array iteration to delete each chat room
-      const response = await proxy.get("/chatrooms", { headers })
+      const response = await proxy.get("/chatrooms")
       if (response.data.response.chatrooms === null) return
       const { chatrooms } = response.data.response
 
       await Promise.all(
         chatrooms.map(async (chatRoom: ChatRoom) => {
-          await proxy.delete(`/chatrooms/${chatRoom.id}`, { headers })
+          await proxy.delete(`/chatrooms/${chatRoom.id}`)
         }),
       )
       // Update the chat room list

--- a/client/src/containers/home/navigatorBox.tsx
+++ b/client/src/containers/home/navigatorBox.tsx
@@ -14,10 +14,7 @@ export default function NavigatorBox({ onClickInnerButton }: { onClickInnerButto
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([])
 
   const fetchChatRooms = async () => {
-    const headers = {
-      Authorization: getJwtTokenFromStorage(),
-    }
-    const response = await proxy.get("/chatrooms", { headers })
+    const response = await proxy.get("/chatrooms")
     if (response.data.response.chatrooms === null) return
     setChatRooms(response.data.response.chatrooms)
   }
@@ -27,11 +24,8 @@ export default function NavigatorBox({ onClickInnerButton }: { onClickInnerButto
       const requestData = {
         title: newTitle,
       }
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
       fetchChatRooms().then(() => {})
-      await proxy.put(`/chatrooms/${id}`, requestData, { headers })
+      await proxy.put(`/chatrooms/${id}`, requestData)
     } catch (error) {
       alert("채팅방 제목 수정 도중 오류가 발생하였습니다.")
     }
@@ -40,10 +34,7 @@ export default function NavigatorBox({ onClickInnerButton }: { onClickInnerButto
   const handleDeleteChatRoom = async (id: number) => {
     if (id === chatroomId) setChatroomId(0)
     try {
-      const headers = {
-        Authorization: getJwtTokenFromStorage(),
-      }
-      await proxy.delete(`/chatrooms/${id}`, { headers })
+      await proxy.delete(`/chatrooms/${id}`)
     } catch (error) {
       alert("채팅방 삭제 도중 오류가 발생하였습니다.")
     }

--- a/client/src/contexts/authContextProvider.tsx
+++ b/client/src/contexts/authContextProvider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { createContext, ReactNode, useEffect, useMemo, useState } from "react"
-import { getJwtPayload } from "@/utils/jwtDecoder"
+import { deleteJwt, getJwtPayload } from "@/utils/jwtDecoder"
 
 export const AuthContext = createContext<any>({})
 
@@ -31,6 +31,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     if (payload === null) {
       setUserId(0)
       setUserRole("ROLE_PENDING")
+      deleteJwt()
     } else {
       setUserId(payload.id)
       setUserRole(payload.role)

--- a/client/src/utils/jwtDecoder.ts
+++ b/client/src/utils/jwtDecoder.ts
@@ -18,25 +18,15 @@ export function getJwtPayload(jwtString?: string) {
     jwt = jwtString
   } else if (typeof window !== "undefined") {
     const value = sessionStorage.getItem(sessionKey)
-    jwt = value || jwt
+    jwt = value ?? jwt
   }
   if (jwt === null) return null
   const jwtParts = jwt.split(".")
   if (!jwt.startsWith("Bearer ") || jwtParts.length !== 3) {
-    deleteJwt()
     return null
   }
   const decodedPayload = atob(jwtParts[1])
-  const payload = JSON.parse(decodedPayload)
-
-  const expirationTime = payload.exp * 1000
-  const currentTimestamp = Date.now()
-
-  if (currentTimestamp > expirationTime) {
-    deleteJwt()
-    return null
-  }
-  return payload
+  return JSON.parse(decodedPayload)
 }
 
 export function getJwtExp(jwtString?: string) {

--- a/client/src/utils/jwtDecoder.ts
+++ b/client/src/utils/jwtDecoder.ts
@@ -1,14 +1,14 @@
-const sessionKey = "jwt"
+const tokenKey = "jwt"
 
 export function saveJwt(jwt: string) {
   if (typeof window !== "undefined") {
-    sessionStorage.setItem(sessionKey, jwt)
+    localStorage.setItem(tokenKey, jwt)
   }
 }
 
 export function deleteJwt() {
   if (typeof window !== "undefined") {
-    sessionStorage.removeItem(sessionKey)
+    localStorage.removeItem(tokenKey)
   }
 }
 
@@ -17,7 +17,7 @@ export function getJwtPayload(jwtString?: string) {
   if (jwtString) {
     jwt = jwtString
   } else if (typeof window !== "undefined") {
-    const value = sessionStorage.getItem(sessionKey)
+    const value = localStorage.getItem(tokenKey)
     jwt = value ?? jwt
   }
   if (jwt === null) return null
@@ -48,5 +48,5 @@ export function getJwtTokenFromStorage() {
   if (typeof window === "undefined") {
     return null
   }
-  return sessionStorage.getItem(sessionKey)
+  return localStorage.getItem(tokenKey)
 }

--- a/client/src/utils/proxy.ts
+++ b/client/src/utils/proxy.ts
@@ -1,31 +1,11 @@
-import axios, { AxiosRequestConfig } from "axios"
+import axios from "axios"
+import { refresh, refreshErrorHandle } from "@/utils/refresh"
 
-const proxy = {
-  proxyUrl: `${process.env.NEXT_PUBLIC_API_URL}/api`,
-  getUrl(url: string) {
-    return this.proxyUrl + url
-  },
-  getConf(conf: AxiosRequestConfig<any> | undefined) {
-    let newConf: any = {}
-    if (conf !== null && typeof conf !== "undefined") newConf = { ...conf }
-    newConf.withCredentials = true
-    return newConf
-  },
-  put(url: string, data?: object | undefined, conf?: AxiosRequestConfig<any> | undefined) {
-    const convertedUrl = this.getUrl(url)
-    return axios.put(convertedUrl, data, this.getConf(conf))
-  },
-  delete(url: string, conf?: AxiosRequestConfig<any> | undefined) {
-    const convertedUrl = this.getUrl(url)
-    return axios.delete(convertedUrl, this.getConf(conf))
-  },
-  post(url: string, data?: object | undefined, conf?: AxiosRequestConfig<any> | undefined) {
-    const convertedUrl = this.getUrl(url)
-    return axios.post(convertedUrl, data, this.getConf(conf))
-  },
-  get(url: string, conf?: AxiosRequestConfig<any> | undefined) {
-    const convertedUrl = this.getUrl(url)
-    return axios.get(convertedUrl, this.getConf(conf))
-  },
-}
+const proxy = axios.create({
+  baseURL: `${process.env.NEXT_PUBLIC_API_URL}/api`,
+  withCredentials: true,
+})
+
+proxy.interceptors.request.use(refresh, refreshErrorHandle)
+
 export default proxy

--- a/client/src/utils/refresh.ts
+++ b/client/src/utils/refresh.ts
@@ -1,0 +1,23 @@
+import axios, { InternalAxiosRequestConfig } from "axios"
+import { deleteJwt, getJwtExp, saveJwt } from "@/utils/jwtDecoder"
+
+const refresh = async (config: InternalAxiosRequestConfig) => {
+  const jwtExp = getJwtExp()
+  const newConfig = config
+  if (jwtExp != null && jwtExp * 1000 < Date.now()) {
+    const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/authentication`, null, {
+      withCredentials: true,
+    })
+
+    const jwt = res.headers.authorization
+    saveJwt(jwt)
+    newConfig.headers.Authorization = jwt
+  }
+  return newConfig
+}
+
+const refreshErrorHandle = () => {
+  deleteJwt()
+}
+
+export { refresh, refreshErrorHandle }

--- a/client/src/utils/refresh.ts
+++ b/client/src/utils/refresh.ts
@@ -1,5 +1,5 @@
 import axios, { InternalAxiosRequestConfig } from "axios"
-import { deleteJwt, getJwtExp, saveJwt } from "@/utils/jwtDecoder"
+import { deleteJwt, getJwtExp, getJwtTokenFromStorage, saveJwt } from "@/utils/jwtDecoder"
 
 type RefreshCallback = (newToken: string) => void
 
@@ -43,6 +43,8 @@ const refresh = async (config: InternalAxiosRequestConfig) => {
         })
       })
     }
+  } else {
+    newConfig.headers.Authorization = getJwtTokenFromStorage()
   }
   return newConfig
 }

--- a/client/src/utils/refresh.ts
+++ b/client/src/utils/refresh.ts
@@ -1,23 +1,52 @@
 import axios, { InternalAxiosRequestConfig } from "axios"
 import { deleteJwt, getJwtExp, saveJwt } from "@/utils/jwtDecoder"
 
+type RefreshCallback = (newToken: string) => void
+
+let isRefreshing = false
+let refreshSubscribers: RefreshCallback[] = []
+
+function subscribeTokenRefresh(cb: RefreshCallback) {
+  refreshSubscribers.push(cb)
+}
+
+function onRefreshed(token: string) {
+  refreshSubscribers.forEach((cb) => cb(token))
+  refreshSubscribers = []
+}
+
 const refresh = async (config: InternalAxiosRequestConfig) => {
   const jwtExp = getJwtExp()
   const newConfig = config
   if (jwtExp != null && jwtExp * 1000 < Date.now()) {
-    const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/authentication`, null, {
-      withCredentials: true,
-    })
+    if (!isRefreshing) {
+      try {
+        isRefreshing = true
+        const res = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/authentication`, null, {
+          withCredentials: true,
+        })
 
-    const jwt = res.headers.authorization
-    saveJwt(jwt)
-    newConfig.headers.Authorization = jwt
+        const jwt = res.headers.authorization
+        saveJwt(jwt)
+        onRefreshed(jwt)
+        newConfig.headers.Authorization = jwt
+      } catch (e) {
+        deleteJwt()
+      } finally {
+        isRefreshing = false
+      }
+    } else {
+      await new Promise((resolve) => {
+        subscribeTokenRefresh((token: string) => {
+          newConfig.headers.Authorization = token
+          resolve(token)
+        })
+      })
+    }
   }
   return newConfig
 }
 
-const refreshErrorHandle = () => {
-  deleteJwt()
-}
+const refreshErrorHandle = () => {}
 
 export { refresh, refreshErrorHandle }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/server/docker-compose-redis.yml
+++ b/server/docker-compose-redis.yml
@@ -1,0 +1,7 @@
+version: "3.5"
+services:
+  redis:
+    image: redis:6.2
+    container_name: redis
+    ports:
+      - "6379:6379"

--- a/server/src/main/java/net/chatfoodie/server/_core/config/RedisConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package net.chatfoodie.server._core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        // redisTemplate를 받아와서 set, get, delete를 사용
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        // setKeySerializer, setValueSerializer 설정
+        // redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/server/src/main/java/net/chatfoodie/server/_core/security/JwtProvider.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/JwtProvider.java
@@ -4,7 +4,6 @@ package net.chatfoodie.server._core.security;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server.user.User;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -14,29 +13,40 @@ import java.time.LocalDateTime;
 
 @Component
 public class JwtProvider {
-    public static final Long EXP = 1000L * 60 * 60 * 48; // 토큰 유효기간 - 사실 안쓰임
+    public static final int ACCESS_EXP_SEC = 60 * 5;
+    public static final int REFRESH_EXP_SEC = 60 * 60 * 24 * 30;
     public static final String TOKEN_PREFIX = "Bearer "; // 스페이스 필요함
     public static final String HEADER = "Authorization";
-    private static String SECRET;
+    private static String secret;
 
     @Value("${chat-foodie.secret}")
     public void setKey(String value) {
-        SECRET = value;
+        secret = value;
     }
 
-    public static String create(User user) {
+    public static String createAccess(User user) {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime expired = now.plusDays(1);  // 지금 EXP 안쓰고 이걸로 돼있음
+        LocalDateTime expired = now.plusSeconds(ACCESS_EXP_SEC);  // 지금 EXP 안쓰고 이걸로 돼있음
         String jwt = JWT.create()
                 .withExpiresAt(Timestamp.valueOf(expired))
                 .withClaim("id", user.getId())
                 .withClaim("role", String.valueOf(user.getRole()))
-                .sign(Algorithm.HMAC512(SECRET));
+                .sign(Algorithm.HMAC512(secret));
         return TOKEN_PREFIX + jwt;
     }
 
+
+    public static String createRefresh(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expired = now.plusSeconds(REFRESH_EXP_SEC);  // 지금 EXP 안쓰고 이걸로 돼있음
+        return JWT.create()
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .withClaim("id", user.getId())
+                .sign(Algorithm.HMAC512(secret));
+    }
+
     public static DecodedJWT verify(String jwt) {
-        return JWT.require(Algorithm.HMAC512(SECRET)).build()
+        return JWT.require(Algorithm.HMAC512(secret)).build()
                 .verify(jwt.replace(TOKEN_PREFIX, ""));
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
+++ b/server/src/main/java/net/chatfoodie/server/_core/security/SecurityConfig.java
@@ -1,7 +1,6 @@
 package net.chatfoodie.server._core.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletResponse;
 import net.chatfoodie.server._core.config.Configs;
 import net.chatfoodie.server._core.errors.exception.Exception401;
 import net.chatfoodie.server._core.errors.exception.Exception403;
@@ -78,10 +77,10 @@ public class SecurityConfig {
 
         // 10. 인증, 권한 필터 설정
         http.authorizeHttpRequests(authorize ->
-                        authorize.requestMatchers("/api/chatrooms/**").hasRole("USER")
-                                .requestMatchers("/api/email-verifications/**", "/api/users/**").hasAnyRole("PENDING", "USER")
-                                .requestMatchers("/api/validate/**", "/api/help/**").permitAll()
-                                .anyRequest().permitAll()
+                authorize.requestMatchers("/api/chatrooms/**", "/api/logout").hasRole("USER")
+                        .requestMatchers("/api/email-verifications/**", "/api/users/**").hasAnyRole("PENDING", "USER")
+                        .requestMatchers("/api/validate/**", "/api/help/**").permitAll()
+                        .anyRequest().permitAll()
         );
 
         return http.build();

--- a/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
+++ b/server/src/main/java/net/chatfoodie/server/emailVerification/service/EmailVerificationService.java
@@ -1,6 +1,5 @@
 package net.chatfoodie.server.emailVerification.service;
 
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.chatfoodie.server._core.errors.exception.Exception400;
@@ -33,6 +32,7 @@ public class EmailVerificationService {
     final private UserRepository userRepository;
 
     final private JavaMailSender javaMailSender;
+
     @Transactional
     public void sendVerificationCode(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new Exception404("유저를 찾을 수 없습니다."));
@@ -44,9 +44,9 @@ public class EmailVerificationService {
 
         var verificationCode = makeCode();
         var emailVerification = EmailVerification.builder()
-                                                .email(email)
-                                                .verificationCode(verificationCode)
-                                                .build();
+                .email(email)
+                .verificationCode(verificationCode)
+                .build();
 
         sendEmail(email, verificationCode);
 
@@ -82,6 +82,6 @@ public class EmailVerificationService {
         }
 
         user.updateRole(Role.ROLE_USER);
-        return JwtProvider.create(user);
+        return JwtProvider.createAccess(user);
     }
 }

--- a/server/src/main/java/net/chatfoodie/server/user/User.java
+++ b/server/src/main/java/net/chatfoodie/server/user/User.java
@@ -49,7 +49,7 @@ public class User {
     private LocalDateTime createdAt;
 
     @Builder
-    public User(Long id, String loginId, String password, String name, Boolean gender, LocalDate birth, String email, Role role, LocalDateTime created_at) {
+    public User(Long id, String loginId, String password, String name, Boolean gender, LocalDate birth, String email, Role role, LocalDateTime createdAt) {
         this.id = id;
         this.loginId = loginId;
         this.password = password;
@@ -58,7 +58,7 @@ public class User {
         this.birth = birth;
         this.email = email;
         this.role = role;
-        this.createdAt = created_at;
+        this.createdAt = createdAt;
     }
 
     public void updateLoginId(String loginId) {

--- a/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
@@ -59,6 +59,20 @@ public class UserController {
                 .body(response);
     }
 
+    @PostMapping("/authentication")
+    public ResponseEntity<?> reIssueTokens(@CookieValue("refreshToken") String refreshToken) {
+
+
+        var tokensDto = userService.reIssueTokens(refreshToken);
+
+        var responseCookie = createRefreshTokenCookie(tokensDto.refresh());
+
+        var response = ApiUtils.success();
+        return ResponseEntity.ok().header(JwtProvider.HEADER, tokensDto.access())
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(response);
+    }
+
     private static ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true) // javascript 접근 방지

--- a/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
+++ b/server/src/main/java/net/chatfoodie/server/user/controller/UserController.java
@@ -42,9 +42,14 @@ public class UserController {
     @PostMapping("/join")
     public ResponseEntity<?> join(@RequestBody @Valid UserRequest.JoinDto requestDto, Errors errors) {
         validateBirthForm(requestDto.birth());
-        String jwt = userService.join(requestDto);
-        ApiUtils.Response<?> response = ApiUtils.success();
-        return ResponseEntity.ok().header(JwtProvider.HEADER, jwt).body(response);
+        var responseDto = userService.join(requestDto);
+
+        var responseCookie = createRefreshTokenCookie(responseDto.refresh(), JwtProvider.REFRESH_EXP_SEC);
+
+        return ResponseEntity.ok()
+                .header(JwtProvider.HEADER, responseDto.access())
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(ApiUtils.success());
     }
 
     @PostMapping("/login")

--- a/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
+++ b/server/src/main/java/net/chatfoodie/server/user/dto/UserResponse.java
@@ -7,14 +7,14 @@ import java.util.List;
 
 public class UserResponse {
     public record GetUserDto(
-        Long id,
-        String loginId,
-        String name,
-        Boolean gender,
-        String birth,
-        String email,
-        List<FavorDto> favors
-    ){
+            Long id,
+            String loginId,
+            String name,
+            Boolean gender,
+            String birth,
+            String email,
+            List<FavorDto> favors
+    ) {
         public GetUserDto(User user, List<Favor> favors) {
             this(
                     user.getId(),
@@ -43,9 +43,14 @@ public class UserResponse {
             String loginId
     ) {
         public FindUserIdDto(String loginId) {
-            this.loginId = loginId.substring(0,2) + "***" + loginId.substring(loginId.length()-1, loginId.length());
+            this.loginId = loginId.substring(0, 2) + "***" + loginId.substring(loginId.length() - 1, loginId.length());
         }
 
     }
 
+    public record TokensDto(
+            String access,
+            String refresh
+    ) {
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
@@ -211,4 +211,8 @@ public class UserService {
 
         return issueTokens(user);
     }
+
+    public void logout(Long id) {
+        redisTemplate.delete(id.toString());
+    }
 }

--- a/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
@@ -46,7 +46,7 @@ public class UserService {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public String join(UserRequest.JoinDto requestDto) {
+    public UserResponse.TokensDto join(UserRequest.JoinDto requestDto) {
 
         if (!Objects.equals(requestDto.password(), requestDto.passwordCheck())) {
             throw new Exception400("비밀번호 확인이 일치하지 않습니다.");
@@ -65,7 +65,8 @@ public class UserService {
         var user = requestDto.createUser(encodedPassword);
 
         try {
-            return JwtProvider.createAccess(userRepository.save(user));
+            var savedUser = userRepository.save(user);
+            return  issueTokens(savedUser);
         } catch (Exception e) {
             throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
         }

--- a/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
 
         try {
             var savedUser = userRepository.save(user);
-            return  issueTokens(savedUser);
+            return issueTokens(savedUser);
         } catch (Exception e) {
             throw new Exception500("회원가입 중에 오류가 발생했습니다. 다시 시도해주세요.");
         }
@@ -207,8 +207,6 @@ public class UserService {
 
         var user = userRepository.findById(decodedRefreshToken.getClaim("id").asLong()).orElseThrow(() ->
                 new Exception500("재발급 과정에서 오류가 발생했습니다."));
-
-        log.debug(user.getId().toString());
 
         return issueTokens(user);
     }

--- a/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
+++ b/server/src/main/java/net/chatfoodie/server/user/service/UserService.java
@@ -197,4 +197,18 @@ public class UserService {
 
         Utils.sendEmail(javaMailSender, email, subject, text);
     }
+
+    public UserResponse.TokensDto reIssueTokens(String refreshToken) {
+        var decodedRefreshToken = JwtProvider.verify(refreshToken);
+
+        if (!Objects.equals(redisTemplate.opsForValue().get(decodedRefreshToken.getClaim("id").asLong().toString()), refreshToken))
+            throw new Exception401("유효하지 않은 refresh 토큰입니다.");
+
+        var user = userRepository.findById(decodedRefreshToken.getClaim("id").asLong()).orElseThrow(() ->
+                new Exception500("재발급 과정에서 오류가 발생했습니다."));
+
+        log.debug(user.getId().toString());
+
+        return issueTokens(user);
+    }
 }

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -28,6 +28,10 @@ spring:
       encoding: utf-8
   jackson:
     time-zone: Asia/Seoul
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/server/src/main/resources/application-product.yml
+++ b/server/src/main/resources/application-product.yml
@@ -23,6 +23,10 @@ spring:
       encoding: utf-8
   jackson:
     time-zone: Asia/Seoul
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:


### PR DESCRIPTION
## Summary

Refresh 토큰을 추가로 적용하였습니다.

## Description

**백엔드**

- docker container로 redis를 추가하였습니다.
- 로그인 시(or 회원가입 완료, 토큰 재발급) 기존 액세스 토큰과 함께 리프레시 토큰을 전달합니다.
- 액세스 토큰의 유효기간은 2일에서 10분으로 변경하였습니다.
- 액세스 토큰이 만료되었을 때 리프레시 토큰을 사용하여 /authentication으로 POST 요청을 보내 액세스와 리프레시 토큰을 재발급 받습니다.
- 리프레시 토큰은 1회용으로 RTR 전략입니다.
- 리프레시 토큰은 http only cookie로 전달되어 client가 javascript로 접근하지 못하도록 설계하였습니다.

---

**프론트**

- 기존 proxy.ts를 axios instance를 사용하여 baseUrl 등을 설정하도록 refactoring 하였습니다.
- axios interceptors를 사용하여 액세스 토큰 재발급을 자동화 하였습니다.
- 토큰이 필요한 요청에 대해서도 interceptors를 사용하여 자동으로 헤더에 주입하도록 설정하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #143
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->